### PR TITLE
Use the right versions of Arcade workload tasks

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <WixPackageVersion>1.0.0-v3.14.0.5722</WixPackageVersion>
+    <WixPackageVersion>3.14.0-8606.20240208.1</WixPackageVersion>
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="EmscriptenWorkloads">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,8 +34,8 @@
     <DotNetPrivateAssetRootUrl Condition="'$(DotNetPrivateAssetRootUrl)'==''">https://dotnetclimsrc.blob.core.windows.net/dotnet/</DotNetPrivateAssetRootUrl>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftDotNetBuildTasksInstallersVersion>9.0.0-beta.23552.3</MicrosoftDotNetBuildTasksInstallersVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>9.0.0-beta.23552.3</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <WixPackageVersion>1.0.0-v3.14.0.5722</WixPackageVersion>


### PR DESCRIPTION
The workload tasks version was hard-coded and out of sync with the right version of arcade, which meant that the changes from https://github.com/dotnet/arcade/pull/14499 weren't being used.