### PR TITLE
Update main for preview 5 versions and ability to publish builds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,14 @@
   </solution>
   <packageSources>
     <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-aspire -->
+    <!--  End: Package sources from dotnet-aspire -->
+    <!--  Begin: Package sources from dotnet-emsdk -->
+    <!--  End: Package sources from dotnet-emsdk -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <!--  End: Package sources from dotnet-runtime -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
@@ -17,5 +25,9 @@
   </packageSources>
   <disabledPackageSources>
     <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <!--  End: Package sources from dotnet-runtime -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
   </disabledPackageSources>
 </configuration>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.3.24171.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.5.24306.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>cf04702e491fda54fa8f729cf494b01d96a9738e</Sha>
+      <Sha>068f59873f1dc5ae74eef9bbe82b847b74560d99</Sha>
       <SourceBuild RepoName="emsdk" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.3.24172.9">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.5.24306.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>9e6ba1f68c6a9c7206dacdf1e4cac67ea19931eb</Sha>
+      <Sha>a5cc707d976a14495462c9c492a921ff0927b8f5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Aspire.Manifest-9.0.100-preview.1" Version="9.0.0-preview.3.24210.17">
       <Uri>https://github.com/dotnet/aspire</Uri>
       <Sha>c2d83148f169bdf4980393a66eff2a28e94eb6c9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100-preview.3" Version="34.99.0-preview.3.231">
+    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100-preview.5" Version="34.99.0-preview.5.308">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
-      <Sha>efadb7d1cf3a360f416cf18457d5ae5e41baf1d8</Sha>
+      <Sha>c8158ac603316d53a692e6928147ec4df55768bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.iOS.Manifest-9.0.100-preview.3" Version="17.2.9433-net9-p3">
+    <Dependency Name="Microsoft.NET.Sdk.iOS.Manifest-9.0.100-preview.5" Version="17.2.9639-net9-p5">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>4eda4114602e7bf173d351f6ffc88a304b1f4aab</Sha>
+      <Sha>3c1eabb8cbc15abd6393cdc87e08ed0414792b8e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.tvOS.Manifest-9.0.100-preview.3" Version="17.2.9433-net9-p3">
+    <Dependency Name="Microsoft.NET.Sdk.tvOS.Manifest-9.0.100-preview.5" Version="17.2.9639-net9-p5">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>4eda4114602e7bf173d351f6ffc88a304b1f4aab</Sha>
+      <Sha>3c1eabb8cbc15abd6393cdc87e08ed0414792b8e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.MacCatalyst.Manifest-9.0.100-preview.3" Version="17.2.9433-net9-p3">
+    <Dependency Name="Microsoft.NET.Sdk.MacCatalyst.Manifest-9.0.100-preview.5" Version="17.2.9639-net9-p5">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>4eda4114602e7bf173d351f6ffc88a304b1f4aab</Sha>
+      <Sha>3c1eabb8cbc15abd6393cdc87e08ed0414792b8e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.macOS.Manifest-9.0.100-preview.3" Version="14.2.9433-net9-p3">
+    <Dependency Name="Microsoft.NET.Sdk.macOS.Manifest-9.0.100-preview.5" Version="14.2.9639-net9-p5">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>4eda4114602e7bf173d351f6ffc88a304b1f4aab</Sha>
+      <Sha>3c1eabb8cbc15abd6393cdc87e08ed0414792b8e</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <WorkloadsVersion>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature).$(VersionPatch)</WorkloadsVersion>
     <MajorMinorVersion>$(VersionMajor).$(VersionMinor)</MajorMinorVersion>
     <CliProductBandVersion>$(MajorMinorVersion).$(VersionSDKMinor)</CliProductBandVersion>
-    <SDKFeatureBand>$(CliProductBandVersion)00</SDKFeatureBand>
+    <SdkFeatureBand>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)00</SdkFeatureBand>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
@@ -25,7 +25,8 @@
     <PreReleaseVersionLabel Condition="'$(StabilizePackageVersion)' != 'true'">preview</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(StabilizePackageVersion)' == 'true' and '$(VersionFeature)' == '00'">rtm</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(StabilizePackageVersion)' == 'true' and '$(VersionFeature)' != '00'">servicing</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'">3</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'">5</PreReleaseVersionIteration>
+    <SDKFeatureBand Condition="'$(StabilizePackageVersion)' != 'true'">$(SDKFeatureBand)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</SDKFeatureBand>
   </PropertyGroup>
   <!-- Restore feeds -->
   <PropertyGroup Label="Restore feeds">
@@ -38,7 +39,7 @@
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <WixPackageVersion>1.0.0-v3.14.0.5722</WixPackageVersion>
+    <WixPackageVersion>3.14.0-8606.20240208.1</WixPackageVersion>
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="EmscriptenWorkloads">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,19 +44,19 @@
   </PropertyGroup>
   <PropertyGroup Label="EmscriptenWorkloads">
     <!-- Workloads from dotnet/emsdk -->
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportPackageVersion>9.0.0-preview.3.24171.4</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportPackageVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportPackageVersion>9.0.0-preview.5.24306.1</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportPackageVersion>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportPackageVersion)</EmscriptenWorkloadManifestVersion>
     <!-- emsdk workload prerelease version band must match the emsdk feature band -->
     <EmscriptenWorkloadFeatureBand>9.0.100$([System.Text.RegularExpressions.Regex]::Match($(EmscriptenWorkloadManifestVersion), `-[A-z]*[\.]*\d*`))</EmscriptenWorkloadFeatureBand>
   </PropertyGroup>
   <PropertyGroup Label="MauiWorkloads">
-    <MauiFeatureBand>9.0.100-preview3</MauiFeatureBand>
+    <MauiFeatureBand>9.0.100-preview5</MauiFeatureBand>
     <MicrosoftNETSdkAndroidManifest90100preview3PackageVersion>34.99.0-preview.3.231</MicrosoftNETSdkAndroidManifest90100preview3PackageVersion>
     <MicrosoftNETSdkiOSManifest90100preview3PackageVersion>17.2.9433-net9-p3</MicrosoftNETSdkiOSManifest90100preview3PackageVersion>
     <MicrosoftNETSdktvOSManifest90100preview3PackageVersion>17.2.9433-net9-p3</MicrosoftNETSdktvOSManifest90100preview3PackageVersion>
     <MicrosoftNETSdkMacCatalystManifest90100preview3PackageVersion>17.2.9433-net9-p3</MicrosoftNETSdkMacCatalystManifest90100preview3PackageVersion>
     <MicrosoftNETSdkmacOSManifest90100preview3PackageVersion>14.2.9433-net9-p3</MicrosoftNETSdkmacOSManifest90100preview3PackageVersion>
-    <MauiWorkloadManifestVersion>9.0.0-preview.3.10457</MauiWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>9.0.0-preview.5.24307.10</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest90100preview3PackageVersion)</XamarinAndroidWorkloadManifestVersion>
     <XamarinIOSWorkloadManifestVersion>$(MicrosoftNETSdkiOSManifest90100preview3PackageVersion)</XamarinIOSWorkloadManifestVersion>
     <XamarinMacCatalystWorkloadManifestVersion>$(MicrosoftNETSdkMacCatalystManifest90100preview3PackageVersion)</XamarinMacCatalystWorkloadManifestVersion>
@@ -64,7 +64,7 @@
     <XamarinTvOSWorkloadManifestVersion>$(MicrosoftNETSdktvOSManifest90100preview3PackageVersion)</XamarinTvOSWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup Label="MonoWorkloads">
-    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.3.24172.9</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.5.24306.7</MicrosoftNETCoreAppRefPackageVersion>
     <!-- Workloads from dotnet/runtime use MicrosoftNETCoreAppRefPackageVersion because it has a stable name that does not include the full feature band -->
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <!-- mono workload prerelease version band must match the runtime feature band -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,17 +51,17 @@
   </PropertyGroup>
   <PropertyGroup Label="MauiWorkloads">
     <MauiFeatureBand>9.0.100-preview5</MauiFeatureBand>
-    <MicrosoftNETSdkAndroidManifest90100preview3PackageVersion>34.99.0-preview.3.231</MicrosoftNETSdkAndroidManifest90100preview3PackageVersion>
-    <MicrosoftNETSdkiOSManifest90100preview3PackageVersion>17.2.9433-net9-p3</MicrosoftNETSdkiOSManifest90100preview3PackageVersion>
-    <MicrosoftNETSdktvOSManifest90100preview3PackageVersion>17.2.9433-net9-p3</MicrosoftNETSdktvOSManifest90100preview3PackageVersion>
-    <MicrosoftNETSdkMacCatalystManifest90100preview3PackageVersion>17.2.9433-net9-p3</MicrosoftNETSdkMacCatalystManifest90100preview3PackageVersion>
-    <MicrosoftNETSdkmacOSManifest90100preview3PackageVersion>14.2.9433-net9-p3</MicrosoftNETSdkmacOSManifest90100preview3PackageVersion>
+    <MicrosoftNETSdkAndroidManifest90100preview5PackageVersion>34.99.0-preview.5.308</MicrosoftNETSdkAndroidManifest90100preview5PackageVersion>
+    <MicrosoftNETSdkiOSManifest90100preview5PackageVersion>17.2.9639-net9-p5</MicrosoftNETSdkiOSManifest90100preview5PackageVersion>
+    <MicrosoftNETSdktvOSManifest90100preview5PackageVersion>17.2.9639-net9-p5</MicrosoftNETSdktvOSManifest90100preview5PackageVersion>
+    <MicrosoftNETSdkMacCatalystManifest90100preview5PackageVersion>17.2.9639-net9-p5</MicrosoftNETSdkMacCatalystManifest90100preview5PackageVersion>
+    <MicrosoftNETSdkmacOSManifest90100preview5PackageVersion>14.2.9639-net9-p5</MicrosoftNETSdkmacOSManifest90100preview5PackageVersion>
     <MauiWorkloadManifestVersion>9.0.0-preview.5.24307.10</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest90100preview3PackageVersion)</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>$(MicrosoftNETSdkiOSManifest90100preview3PackageVersion)</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>$(MicrosoftNETSdkMacCatalystManifest90100preview3PackageVersion)</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>$(MicrosoftNETSdkmacOSManifest90100preview3PackageVersion)</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>$(MicrosoftNETSdktvOSManifest90100preview3PackageVersion)</XamarinTvOSWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest90100preview5PackageVersion)</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>$(MicrosoftNETSdkiOSManifest90100preview5PackageVersion)</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>$(MicrosoftNETSdkMacCatalystManifest90100preview5PackageVersion)</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>$(MicrosoftNETSdkmacOSManifest90100preview5PackageVersion)</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>$(MicrosoftNETSdktvOSManifest90100preview5PackageVersion)</XamarinTvOSWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup Label="MonoWorkloads">
     <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.5.24306.7</MicrosoftNETCoreAppRefPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,7 +50,7 @@
     <EmscriptenWorkloadFeatureBand>9.0.100$([System.Text.RegularExpressions.Regex]::Match($(EmscriptenWorkloadManifestVersion), `-[A-z]*[\.]*\d*`))</EmscriptenWorkloadFeatureBand>
   </PropertyGroup>
   <PropertyGroup Label="MauiWorkloads">
-    <MauiFeatureBand>9.0.100-preview5</MauiFeatureBand>
+    <MauiFeatureBand>9.0.100-preview.5</MauiFeatureBand>
     <MicrosoftNETSdkAndroidManifest90100preview5PackageVersion>34.99.0-preview.5.308</MicrosoftNETSdkAndroidManifest90100preview5PackageVersion>
     <MicrosoftNETSdkiOSManifest90100preview5PackageVersion>17.2.9639-net9-p5</MicrosoftNETSdkiOSManifest90100preview5PackageVersion>
     <MicrosoftNETSdktvOSManifest90100preview5PackageVersion>17.2.9639-net9-p5</MicrosoftNETSdktvOSManifest90100preview5PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,7 +71,7 @@
     <MonoWorkloadFeatureBand>9.0.100$([System.Text.RegularExpressions.Regex]::Match($(MonoWorkloadManifestVersion), `-[A-z]*[\.]*\d*`))</MonoWorkloadFeatureBand>
   </PropertyGroup>
   <PropertyGroup Label="AspireWorkloads">
-    <AspireFeatureBand>9.0.100-preview1</AspireFeatureBand>
+    <AspireFeatureBand>9.0.100-preview.1</AspireFeatureBand>
     <MicrosoftNETSdkAspireManifest90100preview1PackageVersion>9.0.0-preview.3.24210.17</MicrosoftNETSdkAspireManifest90100preview1PackageVersion>
     <AspireWorkloadManifestVersion>$(MicrosoftNETSdkAspireManifest90100preview1PackageVersion)</AspireWorkloadManifestVersion>
   </PropertyGroup>

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -26,7 +26,7 @@ parameters:
 - name: feedToPublishTo
   displayName: Feed to publish to
   type: string
-  default: 'public/dotnet8-workloads'
+  default: 'public/dotnet9-workloads'
 
 # Note: Only add pipeline variables if they apply to most of the stages/jobs.
 variables:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -17,6 +17,17 @@ trigger: none
 # See: https://docs.microsoft.com/azure/devops/pipelines/yaml-schema/pr?view=azure-pipelines#examples
 pr: none
 
+parameters:
+# When true, tries to publish
+- name: publishToFeed
+  displayName: Publish to feed
+  type: boolean
+  default: false
+- name: feedToPublishTo
+  displayName: Feed to publish to
+  type: string
+  default: 'public/dotnet8-workloads'
+
 # Note: Only add pipeline variables if they apply to most of the stages/jobs.
 variables:
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
@@ -103,7 +114,7 @@ extends:
   parameters:
     pool:
       name: $(DncEngInternalBuildPool)
-      image: 1es-windows-2022-pt
+      image: 1es-windows-2022
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -123,7 +134,7 @@ extends:
           publishAssetsImmediately: true
           enablePublishTestResults: true
           testResultsFormat: vstest
-          enableSourceIndex: false
+          enableSourceIndex: ${{ and(eq(variables._RunAsInternal, True), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
           workspace:
             clean: all
           jobs:
@@ -134,7 +145,7 @@ extends:
                 vmImage: windows-latest
               ${{ if eq(variables._RunAsInternal, True) }}:
                 name: $(DncEngInternalBuildPool)
-                demands: ImageOverride -equals 1es-windows-2022-pt
+                demands: ImageOverride -equals 1es-windows-2022
             strategy:
               matrix:
                 release:
@@ -150,6 +161,17 @@ extends:
                 $(_AdditionalBuildArgs)
                 $(_InternalBuildArgs)
               displayName: $(_BuildJobDisplayName)
+            - ${{ if eq(parameters.publishToFeed, true) }}:
+              - task: 1ES.PublishNuget@1
+                displayName: Publish Nuget package
+                inputs:
+                  useDotNetTask: true # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
+                  packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg'
+                  packageParentPath: '$(Build.SourcesDirectory)/artifacts/packages'
+                  publishVstsFeed: ${{ parameters.feedToPublishTo }} # Required when pushing to internal feed.
+                  nuGetFeedType: internal  # Change to external when publishing to external feed
+                  allowPackageConflicts: false # Optional. NuGetCommand task only.
+                  publishPackageMetadata: true # Optional
     - ${{ if eq(variables._RunAsInternal, True) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:


### PR DESCRIPTION
preview 5 released today so I ran update-dependencies based on all of the versions that are currently available on nuget.org for preview 5.

I also merged 8.0.4xx branch into this branch to pick up any improvements I'd made there including the publishing change.