### PR TITLE
Update MAUI workload versions for September for the 8.0.400 feature band

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,8 @@
     <!--  End: Package sources from dotnet-aspire -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <add key="darc-pub-dotnet-emsdk-2674f58" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-2674f58-6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580-6/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-2674f58-5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580-5/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-emsdk-2674f58-4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580-4/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-emsdk-2674f58-3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580-3/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-emsdk-2674f58-2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580-2/nuget/v3/index.json" />
@@ -22,12 +24,13 @@
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-maui -->
     <add key="darc-pub-dotnet-maui-f72a2f1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-f72a2f1b/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-maui-f72a2f1-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-f72a2f1b-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-maui -->
     <!--  Begin: Package sources from dotnet-runtime -->
     <add key="darc-pub-dotnet-runtime-b764692" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-b764692d/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from xamarin-xamarin-macios -->
-    <add key="darc-pub-xamarin-xamarin-macios-bc01f5e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-xamarin-xamarin-macios-bc01f5e0/nuget/v3/index.json" />
+    <add key="darc-pub-xamarin-xamarin-macios-a8d7eab" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-xamarin-xamarin-macios-a8d7eab2/nuget/v3/index.json" />
     <!--  End: Package sources from xamarin-xamarin-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>68175bbe5a39140c642dab294cf184ecf72eece0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.iOS.Manifest-8.0.100" Version="17.5.8030">
+    <Dependency Name="Microsoft.NET.Sdk.iOS.Manifest-8.0.100" Version="18.0.8303">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>bc01f5e06685fd9417a06c91dd963f275e8907a7</Sha>
+      <Sha>a8d7eab24d26b7d2b75dee10a219fa0312f600f2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.tvOS.Manifest-8.0.100" Version="17.5.8030">
+    <Dependency Name="Microsoft.NET.Sdk.tvOS.Manifest-8.0.100" Version="18.0.8303">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>bc01f5e06685fd9417a06c91dd963f275e8907a7</Sha>
+      <Sha>a8d7eab24d26b7d2b75dee10a219fa0312f600f2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.MacCatalyst.Manifest-8.0.100" Version="17.5.8030">
+    <Dependency Name="Microsoft.NET.Sdk.MacCatalyst.Manifest-8.0.100" Version="18.0.8303">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>bc01f5e06685fd9417a06c91dd963f275e8907a7</Sha>
+      <Sha>a8d7eab24d26b7d2b75dee10a219fa0312f600f2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.macOS.Manifest-8.0.100" Version="14.5.8030">
+    <Dependency Name="Microsoft.NET.Sdk.macOS.Manifest-8.0.100" Version="15.0.8303">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>bc01f5e06685fd9417a06c91dd963f275e8907a7</Sha>
+      <Sha>a8d7eab24d26b7d2b75dee10a219fa0312f600f2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-8.0.100" Version="8.0.82">
       <Uri>https://github.com/dotnet/maui</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
     <MicrosoftNETSdkiOSManifest80100PackageVersion>18.0.8303</MicrosoftNETSdkiOSManifest80100PackageVersion>
     <MicrosoftNETSdktvOSManifest80100PackageVersion>18.0.8303</MicrosoftNETSdktvOSManifest80100PackageVersion>
     <MicrosoftNETSdkMacCatalystManifest80100PackageVersion>18.0.8303</MicrosoftNETSdkMacCatalystManifest80100PackageVersion>
-    <MicrosoftNETSdkmacOSManifest80100PackageVersion>14.0.8303</MicrosoftNETSdkmacOSManifest80100PackageVersion>
+    <MicrosoftNETSdkmacOSManifest80100PackageVersion>15.0.8303</MicrosoftNETSdkmacOSManifest80100PackageVersion>
     <MicrosoftNETSdkMauiManifest80100PackageVersion>8.0.82</MicrosoftNETSdkMauiManifest80100PackageVersion>
     <MauiWorkloadManifestVersion>$(MicrosoftNETSdkMauiManifest80100PackageVersion)</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest80100PackageVersion)</XamarinAndroidWorkloadManifestVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,10 +53,10 @@
   <PropertyGroup Label="MauiWorkloads">
     <MauiFeatureBand>8.0.100</MauiFeatureBand>
     <MicrosoftNETSdkAndroidManifest80100PackageVersion>34.0.138</MicrosoftNETSdkAndroidManifest80100PackageVersion>
-    <MicrosoftNETSdkiOSManifest80100PackageVersion>17.5.8030</MicrosoftNETSdkiOSManifest80100PackageVersion>
-    <MicrosoftNETSdktvOSManifest80100PackageVersion>17.5.8030</MicrosoftNETSdktvOSManifest80100PackageVersion>
-    <MicrosoftNETSdkMacCatalystManifest80100PackageVersion>17.5.8030</MicrosoftNETSdkMacCatalystManifest80100PackageVersion>
-    <MicrosoftNETSdkmacOSManifest80100PackageVersion>14.5.8030</MicrosoftNETSdkmacOSManifest80100PackageVersion>
+    <MicrosoftNETSdkiOSManifest80100PackageVersion>18.0.8303</MicrosoftNETSdkiOSManifest80100PackageVersion>
+    <MicrosoftNETSdktvOSManifest80100PackageVersion>18.0.8303</MicrosoftNETSdktvOSManifest80100PackageVersion>
+    <MicrosoftNETSdkMacCatalystManifest80100PackageVersion>18.0.8303</MicrosoftNETSdkMacCatalystManifest80100PackageVersion>
+    <MicrosoftNETSdkmacOSManifest80100PackageVersion>14.0.8303</MicrosoftNETSdkmacOSManifest80100PackageVersion>
     <MicrosoftNETSdkMauiManifest80100PackageVersion>8.0.82</MicrosoftNETSdkMauiManifest80100PackageVersion>
     <MauiWorkloadManifestVersion>$(MicrosoftNETSdkMauiManifest80100PackageVersion)</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest80100PackageVersion)</XamarinAndroidWorkloadManifestVersion>


### PR DESCRIPTION
I bumped the versions directly - but do we need darc-based version bumps for these?