### PR TITLE
Add tool to generate test workload sets locally

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,8 +15,6 @@
     <VersionPrefix>$(VersionMajor).$(VersionSDKMinor)$(VersionFeature).$(VersionPatch)</VersionPrefix>
     <!-- Use three part version for the workloads version and include in the readme if it's the .0 release or a preview -->
     <WorkloadsVersion>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</WorkloadsVersion>
-    <MajorMinorVersion>$(VersionMajor).$(VersionMinor)</MajorMinorVersion>
-    <CliProductBandVersion>$(MajorMinorVersion).$(VersionSDKMinor)</CliProductBandVersion>
     <SdkFeatureBand>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)00</SdkFeatureBand>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>

--- a/src/GenerateTestWorkloadSets/GenerateTestWorkloadSets.csproj
+++ b/src/GenerateTestWorkloadSets/GenerateTestWorkloadSets.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="2.0.0-preview.1.24406.1"/>
+	</ItemGroup>
+
+</Project>

--- a/src/GenerateTestWorkloadSets/Program.cs
+++ b/src/GenerateTestWorkloadSets/Program.cs
@@ -1,0 +1,45 @@
+﻿// See https://aka.ms/new-console-template for more information
+using GenerateTestWorkloadSets;
+using System.Text;
+
+List<WorkloadSetInfo> workloadSetsToCreate = [
+        new WorkloadSetInfo("9.0.100", ReleasedWorkloadVersions.Rollback9_0_100_preview7_24414_1),
+        new WorkloadSetInfo("9.0.101-servicing.preview.1", ReleasedWorkloadVersions.Rollback9_0_100_preview7_and_rc1),
+        new WorkloadSetInfo("9.0.101", ReleasedWorkloadVersions.Rollback9_0_100_rc1_24453_3)
+    ];
+
+StringBuilder buildScript = new StringBuilder();
+
+foreach (var workloadSetInfo in workloadSetsToCreate)
+{
+    ProcessWorkloadSet(workloadSetInfo, buildScript, Environment.CurrentDirectory);
+}
+
+buildScript.AppendLine("@echo Done");
+
+buildScript.AppendLine();
+buildScript.AppendLine(":End");
+
+
+var buildScriptPath = Path.GetFullPath("buildWorkloads.bat");
+
+File.WriteAllText(buildScriptPath, buildScript.ToString());
+
+Console.WriteLine("Build script path: " + buildScriptPath);
+
+
+void ProcessWorkloadSet(WorkloadSetInfo workloadSetInfo, StringBuilder buildScript, string outputPath)
+{
+    string workloadsPropsOutput = Path.Combine(outputPath, $"workloads-{workloadSetInfo.WorkloadSetVersion}.props");
+    File.WriteAllText(workloadsPropsOutput, workloadSetInfo.ToWorkloadsProps());
+
+    List<string> buildArgs = [
+        ..WorkloadSetProperties.CreateFromWorkloadSetVersion(workloadSetInfo.WorkloadSetVersion).CreateCommandLineArgs(),
+        $"/p:WorkloadsProps={workloadsPropsOutput}",
+    ];
+
+    buildScript.AppendLine("@echo Building workload set " + workloadSetInfo.WorkloadSetVersion);
+    buildScript.AppendLine("call build -bl " + string.Join(' ', buildArgs));
+    buildScript.AppendLine("IF ERRORLEVEL 1 GOTO END");
+    buildScript.AppendLine();
+}

--- a/src/GenerateTestWorkloadSets/ReleasedWorkloadVersions.cs
+++ b/src/GenerateTestWorkloadSets/ReleasedWorkloadVersions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GenerateTestWorkloadSets
+{
+    internal class ReleasedWorkloadVersions
+    {
+        public static string Rollback9_0_100_preview7_24414_1 = """
+            {
+              "Microsoft.NET.Workload.Emscripten.Current": "9.0.0-preview.7.24373.5/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Emscripten.net6": "9.0.0-preview.7.24373.5/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Emscripten.net7": "9.0.0-preview.7.24373.5/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Emscripten.net8": "9.0.0-preview.7.24373.5/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.Android": "35.0.0-preview.7.41/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.iOS": "17.5.9231-net9-p7/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.MacCatalyst": "17.5.9231-net9-p7/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.macOS": "14.5.9231-net9-p7/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.Maui": "9.0.0-preview.7.24407.4/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.tvOS": "17.5.9231-net9-p7/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Mono.ToolChain.Current": "9.0.0-preview.7.24405.7/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Mono.ToolChain.net6": "9.0.0-preview.7.24405.7/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Mono.ToolChain.net7": "9.0.0-preview.7.24405.7/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Mono.ToolChain.net8": "9.0.0-preview.7.24405.7/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.Aspire": "8.1.0/8.0.100"
+            }
+            """;
+
+        //  A combination of preview 7 and rc1 manifest versions
+        public static string Rollback9_0_100_preview7_and_rc1 = """
+            {
+              "Microsoft.NET.Workload.Emscripten.Current": "9.0.0-preview.7.24373.5/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Emscripten.net6": "9.0.0-preview.7.24373.5/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Emscripten.net7": "9.0.0-preview.7.24373.5/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Emscripten.net8": "9.0.0-preview.7.24373.5/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.Android": "35.0.0-preview.7.41/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.iOS": "17.5.9231-net9-p7/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.MacCatalyst": "17.5.9231-net9-p7/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.macOS": "14.5.9231-net9-p7/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.Maui": "9.0.0-preview.7.24407.4/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.tvOS": "17.5.9231-net9-p7/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Mono.ToolChain.Current": "9.0.0-preview.7.24405.7/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Mono.ToolChain.net6": "9.0.0-preview.7.24405.7/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Mono.ToolChain.net7": "9.0.0-preview.7.24405.7/9.0.100-preview.7",
+              "Microsoft.NET.Workload.Mono.ToolChain.net8": "9.0.0-preview.7.24405.7/9.0.100-preview.7",
+              "Microsoft.NET.Sdk.Aspire": "8.2.0/8.0.100"
+            }
+            """;
+
+        public static string Rollback9_0_100_rc1_24453_3 = """
+            {
+              "Microsoft.NET.Workload.Emscripten.Current": "9.0.0-rc.1.24430.3/9.0.100-rc.1",
+              "Microsoft.NET.Workload.Emscripten.net6": "9.0.0-rc.1.24430.3/9.0.100-rc.1",
+              "Microsoft.NET.Workload.Emscripten.net7": "9.0.0-rc.1.24430.3/9.0.100-rc.1",
+              "Microsoft.NET.Workload.Emscripten.net8": "9.0.0-rc.1.24430.3/9.0.100-rc.1",
+              "Microsoft.NET.Sdk.Android": "35.0.0-rc.1.80/9.0.100-rc.1",
+              "Microsoft.NET.Sdk.iOS": "17.5.9270-net9-rc1/9.0.100-rc.1",
+              "Microsoft.NET.Sdk.MacCatalyst": "17.5.9270-net9-rc1/9.0.100-rc.1",
+              "Microsoft.NET.Sdk.macOS": "14.5.9270-net9-rc1/9.0.100-rc.1",
+              "Microsoft.NET.Sdk.Maui": "9.0.0-rc.1.24453.9/9.0.100-rc.1",
+              "Microsoft.NET.Sdk.tvOS": "17.5.9270-net9-rc1/9.0.100-rc.1",
+              "Microsoft.NET.Workload.Mono.ToolChain.Current": "9.0.0-rc.1.24431.7/9.0.100-rc.1",
+              "Microsoft.NET.Workload.Mono.ToolChain.net6": "9.0.0-rc.1.24431.7/9.0.100-rc.1",
+              "Microsoft.NET.Workload.Mono.ToolChain.net7": "9.0.0-rc.1.24431.7/9.0.100-rc.1",
+              "Microsoft.NET.Workload.Mono.ToolChain.net8": "9.0.0-rc.1.24431.7/9.0.100-rc.1",
+              "Microsoft.NET.Sdk.Aspire": "8.2.0/8.0.100"
+            }
+            """;
+    }
+}

--- a/src/GenerateTestWorkloadSets/SdkFeatureBand.cs
+++ b/src/GenerateTestWorkloadSets/SdkFeatureBand.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Deployment.DotNet.Releases;
+
+namespace Microsoft.NET.Sdk.WorkloadManifestReader
+{
+    public struct SdkFeatureBand : IEquatable<SdkFeatureBand>, IComparable<SdkFeatureBand>
+    {
+        private ReleaseVersion _featureBand;
+
+        public SdkFeatureBand(string? version) : this(new ReleaseVersion(version) ?? throw new ArgumentNullException(nameof(version))) { }
+
+        public SdkFeatureBand(ReleaseVersion version)
+        {
+            var fullVersion = version ?? throw new ArgumentNullException(nameof(version));
+            if (string.IsNullOrEmpty(version.Prerelease) || version.Prerelease.Contains("dev") || version.Prerelease.Contains("ci") || version.Prerelease.Contains("rtm"))
+            {
+                _featureBand = new ReleaseVersion(fullVersion.Major, fullVersion.Minor, fullVersion.SdkFeatureBand);
+            }
+            else
+            {
+                // Treat preview versions as their own feature bands
+                var prereleaseComponents = fullVersion.Prerelease.Split('.');
+                var formattedPrerelease = prereleaseComponents.Length > 1 ?
+                    $"{prereleaseComponents[0]}.{prereleaseComponents[1]}"
+                    : prereleaseComponents[0];
+                _featureBand = new ReleaseVersion(fullVersion.Major, fullVersion.Minor, fullVersion.SdkFeatureBand, formattedPrerelease);
+            }
+        }
+
+        public int Major => _featureBand.Major;
+        public int Minor => _featureBand.Minor;
+
+        public bool Equals(SdkFeatureBand other)
+        {
+            return _featureBand.Equals(other._featureBand);
+        }
+
+        public int CompareTo(SdkFeatureBand other)
+        {
+            return _featureBand.CompareTo(other._featureBand);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is SdkFeatureBand featureBand && Equals(featureBand);
+        }
+
+        public override int GetHashCode()
+        {
+            return _featureBand.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return _featureBand.ToString();
+        }
+
+        public string ToStringWithoutPrerelease()
+        {
+            return new ReleaseVersion(_featureBand.Major, _featureBand.Minor, _featureBand.SdkFeatureBand).ToString();
+        }
+
+        public static bool operator >(SdkFeatureBand a, SdkFeatureBand b) => a.CompareTo(b) > 0;
+
+        public static bool operator <(SdkFeatureBand a, SdkFeatureBand b) => a.CompareTo(b) < 0;
+    }
+}

--- a/src/GenerateTestWorkloadSets/WorkloadSetInfo.cs
+++ b/src/GenerateTestWorkloadSets/WorkloadSetInfo.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.DotNet.Workloads.Workload;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace GenerateTestWorkloadSets
+{
+    internal class WorkloadSetInfo
+    {
+
+        public string WorkloadSetVersion { get; set; }
+
+
+        public List<WorkloadManifestInfo> Manifests { get; set; } = new();
+
+        public WorkloadSetInfo()
+        {
+            
+        }
+
+        public WorkloadSetInfo(string workloadSetVersion, string rollbackJson)
+        {
+            WorkloadSetVersion = workloadSetVersion;
+            LoadManifests(rollbackJson);
+        }
+
+        public void LoadManifests(string rollbackJson)
+        {
+            Manifests.Clear();
+
+            var jsonDictionary = JsonSerializer.Deserialize<Dictionary<string,string>>(rollbackJson);
+
+            foreach (var kvp in jsonDictionary)
+            {
+                string name = kvp.Key;
+                var valueParts = kvp.Value.Split('/');
+                string version = valueParts[0];
+                string featureBand = valueParts[1];
+
+                Manifests.Add(new WorkloadManifestInfo(name, featureBand, version));
+            }
+        }
+
+        public string ToWorkloadsProps()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.AppendLine("<Project>");
+            sb.AppendLine("  <ItemGroup>");
+            foreach (var manifest in Manifests)
+            {
+                sb.AppendLine($"""    <WorkloadManifest Include="{manifest.Name}" FeatureBand="{manifest.FeatureBand}" Version="{manifest.Version}" />""");
+            }
+            sb.AppendLine("  </ItemGroup>");
+            sb.AppendLine("</Project>");
+
+            return sb.ToString();
+        }
+    }
+
+    internal class WorkloadSetProperties
+    {
+        public string WorkloadSetVersion { get; set; }
+        public string VersionMajor { get; set; }
+        public string VersionMinor { get; set; }
+        public string VersionSdkMinor { get; set; }
+        public string VersionFeature { get; set; }
+        public string VersionPatch { get; set; }
+        public string SdkFeatureBand { get; set; }
+
+        public string Version { get; set; }
+
+        public static WorkloadSetProperties CreateFromWorkloadSetVersion(string workloadSetVersion)
+        {
+            WorkloadSetProperties ret = new WorkloadSetProperties();
+            ret.WorkloadSetVersion = workloadSetVersion;
+
+            string[] sections = workloadSetVersion.Split(new char[] { '-', '+' }, 2);
+            string versionCore = sections[0];
+            string? preReleaseOrBuild = sections.Length > 1 ? sections[1] : null;
+
+            string[] coreComponents = versionCore.Split('.');
+            string major = coreComponents[0];
+            string minor = coreComponents[1];
+            string patch = coreComponents[2];
+
+            ret.VersionMajor = major;
+            ret.VersionMinor = minor;
+            ret.VersionSdkMinor = (int.Parse(patch) / 100).ToString();
+            ret.VersionFeature = (int.Parse(patch) % 100).ToString("d2");
+
+            if (coreComponents.Length == 3)
+            {
+                ret.VersionPatch = "0";
+            }
+            else
+            {
+                ret.VersionPatch = coreComponents[3];
+            }
+
+            ret.SdkFeatureBand = Microsoft.DotNet.Workloads.Workload.WorkloadSetVersion.GetFeatureBand(workloadSetVersion).ToString();
+            ret.Version = Microsoft.DotNet.Workloads.Workload.WorkloadSetVersion.ToWorkloadSetPackageVersion(workloadSetVersion, out _);
+
+            return ret;
+        }
+
+        public string[] CreateCommandLineArgs()
+        {
+            return
+                [
+                    $"/p:VersionMajor={VersionMajor}",
+                    $"/p:VersionMinor={VersionMinor}",
+                    $"/p:VersionSdkMinor={VersionSdkMinor}",
+                    $"/p:VersionFeature={VersionFeature}",
+                    $"/p:VersionPatch={VersionPatch}",
+                    $"/p:Version={Version}",
+                    $"/p:SdkFeatureBand={SdkFeatureBand}",
+                    $"/p:WorkloadsVersion={WorkloadSetVersion}",
+                ];
+        }
+
+    }
+
+    internal record WorkloadManifestInfo(string Name, string FeatureBand, string Version);
+    
+}

--- a/src/GenerateTestWorkloadSets/WorkloadSetVersion.cs
+++ b/src/GenerateTestWorkloadSets/WorkloadSetVersion.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.Workloads.Workload
+{
+    static class WorkloadSetVersion
+    {
+        public static string ToWorkloadSetPackageVersion(string workloadSetVersion, out SdkFeatureBand sdkFeatureBand)
+        {
+            string[] sections = workloadSetVersion.Split(new char[] { '-', '+' }, 2);
+            string versionCore = sections[0];
+            string? preReleaseOrBuild = sections.Length > 1 ? sections[1] : null;
+
+            string[] coreComponents = versionCore.Split('.');
+            string major = coreComponents[0];
+            string minor = coreComponents[1];
+            string patch = coreComponents[2];
+
+            string packageVersion = $"{major}.{patch}.";
+            if (coreComponents.Length == 3)
+            {
+                //  No workload set patch version
+                packageVersion += "0";
+
+                //  Use preview specifier (if any) from workload set version as part of SDK feature band
+                sdkFeatureBand = new SdkFeatureBand(workloadSetVersion);
+            }
+            else
+            {
+                //  Workload set version has workload patch version (ie 4 components)
+                packageVersion += coreComponents[3];
+
+                //  Don't include any preview specifiers in SDK feature band
+                sdkFeatureBand = new SdkFeatureBand($"{major}.{minor}.{patch}");
+            }
+
+            if (preReleaseOrBuild != null)
+            {
+                //  Figure out if we split on a '-' or '+'
+                char separator = workloadSetVersion[sections[0].Length];
+                packageVersion += separator + preReleaseOrBuild;
+            }
+
+            return packageVersion;
+        }
+
+        public static SdkFeatureBand GetFeatureBand(string workloadSetVersion)
+        {
+            ToWorkloadSetPackageVersion(workloadSetVersion, out SdkFeatureBand sdkFeatureBand);
+            return sdkFeatureBand;
+        }
+
+        public static string FromWorkloadSetPackageVersion(SdkFeatureBand sdkFeatureBand, string packageVersion)
+        {
+            var releaseVersion = new ReleaseVersion(packageVersion);
+            var patch = releaseVersion.Patch > 0 ? $".{releaseVersion.Patch}" : string.Empty;
+            var release = string.IsNullOrWhiteSpace(releaseVersion.Prerelease) ? string.Empty : $"-{releaseVersion.Prerelease}";
+            return $"{sdkFeatureBand.Major}.{sdkFeatureBand.Minor}.{releaseVersion.Minor}{patch}{release}";
+        }
+    }
+}

--- a/src/Microsoft.NET.Workloads/Microsoft.NET.Workloads.csproj
+++ b/src/Microsoft.NET.Workloads/Microsoft.NET.Workloads.csproj
@@ -53,7 +53,11 @@
     <!-- <ItemsToSign Include="$(PackageId).nupkg" /> -->
   </ItemGroup>
 
-  <Import Project="workloads.props" />
+  <PropertyGroup Condition="'$(WorkloadsProps)' == ''">
+	<WorkloadsProps>workloads.props</WorkloadsProps>
+  </PropertyGroup>
+	
+  <Import Project="$(WorkloadsProps)" />
 
   <Target Name="CreateWorkloadSetJson" BeforeTargets="Build">
     <PropertyGroup>
@@ -100,7 +104,7 @@
 
   <Target Name="CreateVisualStudioMsi" AfterTargets="Build" DependsOnTargets="GetAssemblyVersion;_GenerateMsiVersionString">
     <ItemGroup>
-      <WorkloadSetPackage Include="$(ArtifactsShippingPackagesDir)/Microsoft.NET.Workloads.$(SDKFeatureBand).$(VersionMajor)*.nupkg" />
+      <WorkloadSetPackage Include="$(ArtifactsShippingPackagesDir)/$(PackageId).$(PackageVersion).nupkg" />
     </ItemGroup>
 
     <CreateVisualStudioWorkloadSet

--- a/workload-versions.sln
+++ b/workload-versions.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.7.33920.267
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.NET.Workloads", "src\Microsoft.NET.Workloads\Microsoft.NET.Workloads.csproj", "{7EDB5924-188D-472F-B95B-C5BF6461DB41}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenerateTestWorkloadSets", "src\GenerateTestWorkloadSets\GenerateTestWorkloadSets.csproj", "{55BC9CC1-37A9-4472-B1FE-6B4B94DAA363}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7EDB5924-188D-472F-B95B-C5BF6461DB41}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EDB5924-188D-472F-B95B-C5BF6461DB41}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EDB5924-188D-472F-B95B-C5BF6461DB41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55BC9CC1-37A9-4472-B1FE-6B4B94DAA363}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55BC9CC1-37A9-4472-B1FE-6B4B94DAA363}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55BC9CC1-37A9-4472-B1FE-6B4B94DAA363}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55BC9CC1-37A9-4472-B1FE-6B4B94DAA363}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This adds a tool which helps create multiple workload sets for testing, where the exact version number and manifest versions for each workload set can be specified.