### PR TITLE
Remove aspire from darc flow

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,10 +9,6 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>91b783edc518e9ea0c0e883016b02261893389db</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Aspire.Manifest-8.0.100" Version="8.2.2">
-      <Uri>https://github.com/dotnet/aspire</Uri>
-      <Sha>2c38f6c884b5026a7f278cdfe6e1f816810093f9</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-8.0.100" Version="34.0.143">
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>45bb7f365f1587a7786d5bbbf0daec075d5aabea</Sha>


### PR DESCRIPTION
They don't plan on future updates to the 8.0.100 workload so no need to keep the flow. This'll simplify our build logic as well.