### PR TITLE
Add the ability to create a stable package version based on a checkbox (#266)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,10 +19,11 @@
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-    <!-- Calculate prerelease label -->
-    <PreReleaseVersionLabel Condition="'$(StabilizePackageVersion)' != 'true'">servicing</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'">
-    </PreReleaseVersionIteration>
+    <!-- Calculate prerelease label
+    Use preview and prerelease version 0 for SDK feature band previews
+    Use preview and the matching SDK preview version for Major version previews -->
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'"></PreReleaseVersionIteration>
     <SDKFeatureBand Condition="'$(StabilizePackageVersion)' != 'true' and $(PreReleaseVersionLabel) != 'servicing'">$(SDKFeatureBand)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</SDKFeatureBand>
     <!-- Use four part version if it's not a preview and not the .0 release-->
     <WorkloadsVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(VersionPatch)' != '0'">$(WorkloadsVersion).$(VersionPatch)</WorkloadsVersion>

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -19,6 +19,10 @@ pr: none
 
 parameters:
 # When true, tries to publish
+- name: StabilizePackageVersion
+  displayName: Stabilize Package Version
+  type: boolean
+  default: false
 - name: publishToFeed
   displayName: Publish to feed
   type: boolean
@@ -101,6 +105,7 @@ variables:
       /p:TeamName=$(_TeamName)
       /p:DotNetPublishUsingPipelines=true
       /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+      /p:StabilizePackageVersion=${{ parameters.StabilizePackageVersion }}
   - name: PostBuildSign
     value: true
 resources:


### PR DESCRIPTION
* pass the parameter value through

* Always set the prereleaseversionlabel to servicing as it has to be set to something or else arcade adds the build nubmer suffix

* Fix the version patch

* Only add the label to the ID when it's not -servicing

* Add back parameter missed during the cherry-pick