### PR TITLE
Add SDK and coherency dependencies for flow from installer instead of directly from runtime

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -34,8 +34,8 @@
       <Sha>a33a875ef023fdab35aefb57c5f70addd965f3e4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.404-servicing.24521.39">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-sdk</Uri>
-      <Sha>5dd80ae4b107027f86bda68ce91542cad72b2868</Sha>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-installer</Uri>
+      <Sha>7b190310f25ae8d6e735d9b31fb2dbb599e75803</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.11">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.11" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>9cb3b725e3ad2b57ddc9fb2dd48d2d170563a8f5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.11" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.11" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>f6237140b33bf18c72dccfeda14be8d103c3b93e</Sha>
     </Dependency>
@@ -32,6 +32,10 @@
     <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-8.0.100" Version="8.0.83">
       <Uri>https://github.com/dotnet/maui</Uri>
       <Sha>a33a875ef023fdab35aefb57c5f70addd965f3e4</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.404-servicing.24521.39">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-sdk</Uri>
+      <Sha>5dd80ae4b107027f86bda68ce91542cad72b2868</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Once this goes in, we need to modify the existing runtime subscription for this branch to be an installer subscription. I tested locally by running update dependencies for the ID and for the 8.0.4xx channel which I think is the best I can do until this is merged.
