### PR TITLE
Update release/9.0.1xx Maui versions

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
-    <add key="darc-pub-dotnet-android-0ccdc57" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-0ccdc57c/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-maui -->
     <add key="darc-pub-dotnet-maui-85f2a06" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-85f2a06e/nuget/v3/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,25 +10,25 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.39">
+    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.50">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>0ccdc57cf7fc59bd3f6cbf900c9cdbebadfe4609</Sha>
+      <Sha>1719a35b8a0348a4a8dd0061cfc4dd7fe6612a3c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.iOS.Manifest-9.0.100" Version="18.2.9173">
+    <Dependency Name="Microsoft.NET.Sdk.iOS.Manifest-9.0.100" Version="18.2.9180">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>b3ee0f2422cd950a0c0c676fb8ac9e7dc5f98290</Sha>
+      <Sha>63d5ccc690e8c35e0ea0f608b5d05a664f9b7775</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.tvOS.Manifest-9.0.100" Version="18.2.9173">
+    <Dependency Name="Microsoft.NET.Sdk.tvOS.Manifest-9.0.100" Version="18.2.9180">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>b3ee0f2422cd950a0c0c676fb8ac9e7dc5f98290</Sha>
+      <Sha>63d5ccc690e8c35e0ea0f608b5d05a664f9b7775</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.MacCatalyst.Manifest-9.0.100" Version="18.2.9173">
+    <Dependency Name="Microsoft.NET.Sdk.MacCatalyst.Manifest-9.0.100" Version="18.2.9180">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>b3ee0f2422cd950a0c0c676fb8ac9e7dc5f98290</Sha>
+      <Sha>63d5ccc690e8c35e0ea0f608b5d05a664f9b7775</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.macOS.Manifest-9.0.100" Version="15.2.9173">
+    <Dependency Name="Microsoft.NET.Sdk.macOS.Manifest-9.0.100" Version="15.2.9180">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>b3ee0f2422cd950a0c0c676fb8ac9e7dc5f98290</Sha>
+      <Sha>63d5ccc690e8c35e0ea0f608b5d05a664f9b7775</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-9.0.100" Version="9.0.14">
       <Uri>https://github.com/dotnet/maui</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,11 +51,11 @@
   </PropertyGroup>
   <PropertyGroup Label="MauiWorkloads">
     <MauiFeatureBand>9.0.100</MauiFeatureBand>
-    <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.39</MicrosoftNETSdkAndroidManifest90100PackageVersion>
-    <MicrosoftNETSdkiOSManifest90100PackageVersion>18.2.9173</MicrosoftNETSdkiOSManifest90100PackageVersion>
-    <MicrosoftNETSdktvOSManifest90100PackageVersion>18.2.9173</MicrosoftNETSdktvOSManifest90100PackageVersion>
-    <MicrosoftNETSdkMacCatalystManifest90100PackageVersion>18.2.9173</MicrosoftNETSdkMacCatalystManifest90100PackageVersion>
-    <MicrosoftNETSdkmacOSManifest90100PackageVersion>15.2.9173</MicrosoftNETSdkmacOSManifest90100PackageVersion>
+    <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.50</MicrosoftNETSdkAndroidManifest90100PackageVersion>
+    <MicrosoftNETSdkiOSManifest90100PackageVersion>18.2.9180</MicrosoftNETSdkiOSManifest90100PackageVersion>
+    <MicrosoftNETSdktvOSManifest90100PackageVersion>18.2.9180</MicrosoftNETSdktvOSManifest90100PackageVersion>
+    <MicrosoftNETSdkMacCatalystManifest90100PackageVersion>18.2.9180</MicrosoftNETSdkMacCatalystManifest90100PackageVersion>
+    <MicrosoftNETSdkmacOSManifest90100PackageVersion>15.2.9180</MicrosoftNETSdkmacOSManifest90100PackageVersion>
     <MicrosoftNETSdkMauiManifest90100PackageVersion>9.0.14</MicrosoftNETSdkMauiManifest90100PackageVersion>
     <MauiWorkloadManifestVersion>$(MicrosoftNETSdkMauiManifest90100PackageVersion)</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</XamarinAndroidWorkloadManifestVersion>


### PR DESCRIPTION
## Summary

There doesn't seem to be DARC flow for workloads to the release/9.0.1xx branch (I'm not sure why). So, for Maui, I'm updating the versions manually based on the same versions for [2xx](https://github.com/dotnet/workload-versions/pull/317)/[3xx](https://github.com/dotnet/workload-versions/pull/318).