### PR TITLE
Add package metadata for the workload set package

### DIFF
--- a/src/Microsoft.NET.Workloads/Microsoft.NET.Workloads.csproj
+++ b/src/Microsoft.NET.Workloads/Microsoft.NET.Workloads.csproj
@@ -16,6 +16,8 @@
     <!-- See: https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/ -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ReadmeFile>$(IntermediateOutputPath)README.md</ReadmeFile>
+    <PackageProjectUrl>https://learn.microsoft.com/dotnet/core/tools/dotnet-workload-sets</PackageProjectUrl>
+    <Description>This package contains the workload set manifest for the $(SDKFeatureBand) version of the .NET SDK. This package is not intended for direct reference - instead it is an internal implementation detail of the 'dotnet workload' command. See https://learn.microsoft.com/dotnet/core/tools/dotnet-workload-sets for more details.</Description>
     <!-- LGHT1105: Warning generated from MSI creation process. -->
     <!-- See: https://github.com/orgs/wixtoolset/discussions/6715 -->
     <NoWarn>LGHT1105</NoWarn>


### PR DESCRIPTION
Provide PackageProjectUrl and Description so that the package on NuGet.org looks more polished.

Today we get the following:

![image](https://github.com/user-attachments/assets/d97e377f-7b85-4fe7-86cf-82540554475b)

This...doesn't inspire confidence.