### PR TITLE
[CI] Publish: Do not require check parameter

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -14,10 +14,6 @@ parameters:
   displayName: Stabilize package version
   type: boolean
   default: false
-- name: publishToFeed
-  displayName: Publish to feed
-  type: boolean
-  default: false
 - name: feedForPublishing
   displayName: Feed for publishing
   type: string
@@ -140,5 +136,4 @@ extends:
                   targetPath: $(Pipeline.Workspace)/PackageArtifacts
               - template: /eng/pipelines/templates/steps/workload-publish.yml@self
                 parameters:
-                  publishToFeed: ${{ parameters.publishToFeed }}
                   feedForPublishing: ${{ parameters.feedForPublishing }}

--- a/eng/pipelines/templates/steps/workload-publish.yml
+++ b/eng/pipelines/templates/steps/workload-publish.yml
@@ -1,10 +1,9 @@
 parameters:
-  publishToFeed: false
   feedForPublishing: ''
 
 steps:
 - task: 1ES.PublishNuget@1
-  condition: ${{ eq(parameters.publishToFeed, true) }}
+  condition: ${{ neq(parameters.feedForPublishing, '') }}
   displayName: 🟣 Publish package to AzDO
   inputs:
     useDotNetTask: true


### PR DESCRIPTION
Having a check for publish to feed and an approval button is redundant and will cause packages to not publish on automated builds.