### PR TITLE
Prep for maui 9.0.51 release

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -13,6 +13,7 @@
     <add key="darc-pub-dotnet-macios-dd5e708" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-dd5e708b/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--  Begin: Package sources from dotnet-maui -->
+    <add key="darc-pub-dotnet-maui-dd13512" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-dd13512d/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-maui -->
     <!--  Begin: Package sources from dotnet-aspire -->
     <!--  End: Package sources from dotnet-aspire -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,9 +30,9 @@
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>dd5e708b171daffa6d8f3561aee062425a380670</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-9.0.100" Version="9.0.14">
+    <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-9.0.100" Version="9.0.51">
       <Uri>https://github.com/dotnet/maui</Uri>
-      <Sha>85f2a06ecd11e4ba5a9e567d86f9d2fb49a2c5ca</Sha>
+      <Sha>dd13512d027bd88f1ecfe7ed92fcf96e7c2e48f6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="9.0.300-preview.0.25180.2">
       <Uri>https://github.com/dotnet/sdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,7 +55,7 @@
     <MicrosoftNETSdktvOSManifest90100PackageVersion>18.4.9288</MicrosoftNETSdktvOSManifest90100PackageVersion>
     <MicrosoftNETSdkMacCatalystManifest90100PackageVersion>18.4.9288</MicrosoftNETSdkMacCatalystManifest90100PackageVersion>
     <MicrosoftNETSdkmacOSManifest90100PackageVersion>15.4.9288</MicrosoftNETSdkmacOSManifest90100PackageVersion>
-    <MicrosoftNETSdkMauiManifest90100PackageVersion>9.0.14</MicrosoftNETSdkMauiManifest90100PackageVersion>
+    <MicrosoftNETSdkMauiManifest90100PackageVersion>9.0.51</MicrosoftNETSdkMauiManifest90100PackageVersion>
     <MauiWorkloadManifestVersion>$(MicrosoftNETSdkMauiManifest90100PackageVersion)</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</XamarinAndroidWorkloadManifestVersion>
     <XamarinIOSWorkloadManifestVersion>$(MicrosoftNETSdkiOSManifest90100PackageVersion)</XamarinIOSWorkloadManifestVersion>


### PR DESCRIPTION
Update dependencies from https://github.com/dotnet/maui build 9.0.51+azdo.11431602

Microsoft.NET.Sdk.Maui.Manifest-9.0.100
 From Version 9.0.14 -> To Version 9.0.51