### PR TITLE
[CI] Publish: Fix SBOM error

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -135,6 +135,7 @@ extends:
                   artifactName: PackageArtifacts
                   targetPath: $(Pipeline.Workspace)/PackageArtifacts
                   sbomEnabled: false
+                  sbomValidate: false
               - template: /eng/pipelines/templates/steps/workload-publish.yml@self
                 parameters:
                   feedForPublishing: ${{ parameters.feedForPublishing }}

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -132,10 +132,8 @@ extends:
               - task: 1ES.DownloadPipelineArtifact@1
                 displayName: 🟣 Import PackageArtifacts from Previous Stage
                 inputs:
-                  artifactName: PackageArtifacts
-                  targetPath: $(Pipeline.Workspace)/PackageArtifacts
-                  sbomEnabled: false
-                  sbomValidate: false
+                  artifactName: Artifacts_Windows_NT_Release
+                  targetPath: $(Pipeline.Workspace)/Artifacts_Windows_NT_Release
               - template: /eng/pipelines/templates/steps/workload-publish.yml@self
                 parameters:
                   feedForPublishing: ${{ parameters.feedForPublishing }}

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -134,6 +134,7 @@ extends:
                 inputs:
                   artifactName: PackageArtifacts
                   targetPath: $(Pipeline.Workspace)/PackageArtifacts
+                  sbomEnabled: false
               - template: /eng/pipelines/templates/steps/workload-publish.yml@self
                 parameters:
                   feedForPublishing: ${{ parameters.feedForPublishing }}

--- a/eng/pipelines/templates/steps/workload-publish.yml
+++ b/eng/pipelines/templates/steps/workload-publish.yml
@@ -7,8 +7,8 @@ steps:
   displayName: 🟣 Publish package to AzDO
   inputs:
     useDotNetTask: true
-    packagesToPush: $(Pipeline.Workspace)/PackageArtifacts/*.nupkg
-    packageParentPath: $(Pipeline.Workspace)/PackageArtifacts
+    packagesToPush: $(Pipeline.Workspace)/Artifacts_Windows_NT_Release/packages/Release/Shipping/*.nupkg
+    packageParentPath: $(Pipeline.Workspace)/Artifacts_Windows_NT_Release/
     publishVstsFeed: ${{ parameters.feedForPublishing }}
     nuGetFeedType: internal
     allowPackageConflicts: false


### PR DESCRIPTION
Currently there is an error before publishing to AzDO feeds related to SBOM generation. 

Packages were imported from the previous stage without SBOM information. 
