### PR TITLE
Remove the msi signing details as it's no longer required

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,3 +1,0 @@
-<Project>
-
-</Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,11 +1,3 @@
 <Project>
 
-  <PropertyGroup>
-    <InternalCertificateId Condition="'$(InternalCertificateId)' == ''">MicrosoftDotNet500</InternalCertificateId>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <FileExtensionSignInfo Include=".msi" CertificateName="$(InternalCertificateId)" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
It's done automatically through darc now: https://github.com/dotnet/arcade/commit/d1190b4e5ca51d1ad087483e925f3aa1a086f6d9