### PR TITLE
Add the other workloads to the default insertion list

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -40,6 +40,9 @@ parameters:
   default:
   - emsdk
   - mono
+  - iOS
+  - android
+  - maui
 # These insert (pre)components & packs into VS.
 - name: primaryVsInsertionBranches
   displayName: Primary VS insertion branches


### PR DESCRIPTION
There shouldn't be any harm in including ones that don't need to be updated as the pipeline should noop them.

The benefit of doing this is that we don't accidentally miss one that we were supposed to update (unless there is a duplicate sha which we have seen a few times now).