### PR TITLE
Backport NuGet.org publishing and non-shipping workload flag

### DIFF
--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -71,7 +71,7 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
     }
   }
 
-  Write-Host '❗ After upload, your workload drop will be available at:'
+  Write-Host '⚠︎ After upload, your workload drop will be available at:'
   Write-Host "https://devdiv.visualstudio.com/_apps/hub/ms-vscs-artifact.build-tasks.drop-hub-group-explorer-hub?name=$vsDropName"
 }
 

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -12,8 +12,11 @@
 # $usePreComponents:
 # - If $true, includes *pre.components.zip drops and excludes *components.zip drops.
 # - If $false, excludes *pre.components.zip drops and includes *components.zip drops.
+# $includeNonShipping:
+# - If $true, includes workloads that are in the 'non-shipping' folder.
+# - If $false, excludes workloads that are in the 'non-shipping' folder.
 
-param ([Parameter(Mandatory=$true)] [string] $workloadPath, [SecureString] $gitHubPat, [SecureString] $azDOPat, [string] $workloadListJson = '', [bool] $usePreComponents = $false)
+param ([Parameter(Mandatory=$true)] [string] $workloadPath, [SecureString] $gitHubPat, [SecureString] $azDOPat, [string] $workloadListJson = '', [bool] $usePreComponents = $false, [bool] $includeNonShipping = $false)
 
 ### Local Build ###
 # Local build requires the installation of DARC. See: https://github.com/dotnet/arcade/blob/main/Documentation/Darc.md#setting-up-your-darc-client
@@ -62,6 +65,11 @@ if ($usePreComponents) {
 $assetFilter = "Workload\.VSDrop\.$workloadFilter.*$componentFilter"
 Write-Host "assetFilter: $assetFilter"
 
+$nonShippingFlag = ''
+if ($includeNonShipping) {
+  $nonShippingFlag = '--non-shipping'
+}
+
 # Runs DARC against each workload build to download the drops (if applicable based on the filter).
 $versionDetails | ForEach-Object {
   $darcArguments = @(
@@ -78,6 +86,7 @@ $versionDetails | ForEach-Object {
     '--skip-existing'
     '--continue-on-error'
     '--use-azure-credential-for-blobs'
+    $nonShippingFlag
   )
 
   & $darc ($darcArguments + $ciArguments)

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -14,20 +14,28 @@ parameters:
   displayName: Stabilize package version
   type: boolean
   default: false
-- name: publishToFeed
-  displayName: Publish to feed
+- name: publishToAzDO
+  displayName: Publish to AzDO
   type: boolean
   default: false
-- name: feedForPublishing
-  displayName: Feed for publishing
+- name: azDOPublishFeed
+  displayName: AzDO publish feed
   type: string
   default: public/dotnet9-workloads
+- name: publishToNuGet
+  displayName: Publish to NuGet.org
+  type: boolean
+  default: false
 - name: createVSInsertion
   displayName: Create VS insertion
   type: boolean
   default: false
 - name: usePreComponentsForVSInsertion
   displayName: Use Preview Components for VS insertion
+  type: boolean
+  default: false
+- name: includeNonShippingWorkloads
+  displayName: Include non-shipping workloads
   type: boolean
   default: false
 - name: vsTopicBranch
@@ -103,11 +111,54 @@ extends:
       - template: /eng/pipelines/templates/jobs/workload-build.yml@self
         parameters:
           stabilizePackageVersion: ${{ parameters.stabilizePackageVersion }}
-          publishToFeed: ${{ parameters.publishToFeed }}
-          feedForPublishing: ${{ parameters.feedForPublishing }}
           createVSInsertion: ${{ parameters.createVSInsertion }}
           usePreComponentsForVSInsertion: ${{ parameters.usePreComponentsForVSInsertion }}
+          includeNonShippingWorkloads: ${{ parameters.includeNonShippingWorkloads }}
           vsTopicBranch: ${{ parameters.vsTopicBranch }}
           workloadDropNames: ${{ parameters.workloadDropNames }}
           primaryVsInsertionBranches: ${{ parameters.primaryVsInsertionBranches }}
           secondaryVsInsertionBranches: ${{ parameters.secondaryVsInsertionBranches }}
+    - stage: Publish
+      displayName: Publish
+      dependsOn: Build
+      jobs:
+      - deployment: PublishFeed
+        displayName: Publish to feed
+        environment: DotNet-SDK-Workloads
+        pool:
+          name: $(DncEngInternalBuildPool)
+          image: 1es-windows-2022
+          os: windows
+        templateContext:
+          type: releaseJob
+          isProduction: true
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+              - task: 1ES.DownloadPipelineArtifact@1
+                displayName: 🟣 Download build artifacts
+                inputs:
+                  artifactName: Artifacts
+                  targetPath: $(Build.SourcesDirectory)/artifacts
+              # 1ES docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs/nuget-packages
+              # DotNetCoreCLI@2 docs: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/dotnet-core-cli-v2
+              - ${{ if eq(parameters.publishToAzDO, true) }}:
+                - task: 1ES.PublishNuget@1
+                  displayName: 🟣 Publish packages to AzDO
+                  inputs:
+                    useDotNetTask: true
+                    packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg
+                    packageParentPath: $(Build.SourcesDirectory)/artifacts
+                    publishVstsFeed: ${{ parameters.feedForPublishing }}
+              - ${{ if eq(parameters.publishToNuGet, true) }}:
+                - task: 1ES.PublishNuget@1
+                  displayName: 🟣 Publish packages to NuGet.org
+                  inputs:
+                    useDotNetTask: false
+                    packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg
+                    packageParentPath: $(Build.SourcesDirectory)/artifacts
+                    nuGetFeedType: external
+                    publishVstsFeed: https://api.nuget.org/v3/index.json
+                    # Service connection: https://dev.azure.com/dnceng/internal/_settings/adminservices?resourceId=479fdc43-a27d-4f5f-b2fc-5cf19dce159a
+                    publishFeedCredentials: nuget.org (dotnetframework)

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -20,8 +20,10 @@ jobs:
     enableSbom: true
     artifacts:
       publish:
-        artifacts: true
-        logs: true
+        artifacts:
+          name: Artifacts
+        logs:
+          name: Logs
         manifests: true
     jobs:
     - job: buildRepo
@@ -39,13 +41,14 @@ jobs:
             azureSubscription: DotNetStaging
             scriptType: pscore
             scriptPath: $(Build.SourcesDirectory)/eng/download-workloads.ps1
-            # Note: The second $ for usePreComponents allows the value to resolve as `$true` or `$false`.
+            # Note: The second $ for usePreComponents and includeNonShipping allows the value to resolve as `$true` or `$false`.
             arguments: >-
               -workloadPath '$(Build.SourcesDirectory)/artifacts/workloads'
               -gitHubPat (ConvertTo-SecureString -String '$(BotAccount-dotnet-bot-repo-PAT)' -AsPlainText -Force)
               -azDOPat (ConvertTo-SecureString -String '$(dn-bot-all-drop-rw-code-rw-release-all)' -AsPlainText -Force)
               -workloadListJson '${{ convertToJson(parameters.workloadDropNames) }}'
               -usePreComponents:$${{ parameters.usePreComponentsForVSInsertion }}
+              -includeNonShipping:$${{ parameters.includeNonShippingWorkloads }}
 
       # https://github.com/dotnet/arcade/blob/ccae251ef033746eb0213329953f5e3c1687693b/Documentation/CorePackages/Publishing.md#basic-onboarding-scenario-for-new-repositories-to-the-current-publishing-version-v3
       - powershell: >-
@@ -60,18 +63,6 @@ jobs:
           /p:OfficialBuildId=$(Build.BuildNumber)
           /p:StabilizePackageVersion=${{ parameters.stabilizePackageVersion }}
         displayName: 🟣 Build solution
-
-      - ${{ if eq(parameters.publishToFeed, true) }}:
-        - task: 1ES.PublishNuget@1
-          displayName: 🟣 Publish NuGet package
-          inputs:
-            useDotNetTask: true
-            packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg
-            packageParentPath: $(Build.SourcesDirectory)/artifacts/packages
-            publishVstsFeed: ${{ parameters.feedForPublishing }}
-            nuGetFeedType: internal
-            allowPackageConflicts: false
-            publishPackageMetadata: true
 
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         # The variables comprised of workloadShortName and workloadType are set during create-workload-drops.ps1 in Microsoft.NET.Workloads.Vsman.csproj.


### PR DESCRIPTION
Related: https://github.com/dotnet/workload-versions/pull/366
Related: https://github.com/dotnet/workload-versions/pull/338

## Summary

This backports functionality to the 9.0.1xx branch that is currently in `main`. This includes:
- Ability to publish packages to NuGet.org
- Flag for allowing non-shipping workloads to be processed

See the related PRs for additional details.