### PR TITLE
Run Publish only when needed

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -121,47 +121,48 @@ extends:
           workloadDropNames: ${{ parameters.workloadDropNames }}
           primaryVsInsertionBranches: ${{ parameters.primaryVsInsertionBranches }}
           secondaryVsInsertionBranches: ${{ parameters.secondaryVsInsertionBranches }}
-    - stage: Publish
-      displayName: Publish
-      dependsOn: Build
-      jobs:
-      - deployment: PublishFeed
-        displayName: Publish to feed
-        environment: DotNet-SDK-Workloads
-        pool:
-          name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022
-          os: windows
-        templateContext:
-          type: releaseJob
-          isProduction: true
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-              - task: 1ES.DownloadPipelineArtifact@1
-                displayName: 🟣 Download build artifacts
-                inputs:
-                  artifactName: Artifacts
-                  targetPath: $(Build.SourcesDirectory)/artifacts
-              # 1ES docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs/nuget-packages
-              # DotNetCoreCLI@2 docs: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/dotnet-core-cli-v2
-              - ${{ if eq(parameters.publishToAzDO, true) }}:
-                - task: 1ES.PublishNuget@1
-                  displayName: 🟣 Publish packages to AzDO
+    - ${{ if or(eq(parameters.publishToAzDO, true), eq(parameters.publishToNuGet, true)) }}:
+      - stage: Publish
+        displayName: Publish
+        dependsOn: Build
+        jobs:
+        - deployment: PublishFeed
+          displayName: Publish to feed
+          environment: DotNet-SDK-Workloads
+          pool:
+            name: $(DncEngInternalBuildPool)
+            image: 1es-windows-2022
+            os: windows
+          templateContext:
+            type: releaseJob
+            isProduction: true
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                - task: 1ES.DownloadPipelineArtifact@1
+                  displayName: 🟣 Download build artifacts
                   inputs:
-                    useDotNetTask: true
-                    packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg
-                    packageParentPath: $(Build.SourcesDirectory)/artifacts
-                    publishVstsFeed: ${{ parameters.azDOPublishFeed }}
-              - ${{ if eq(parameters.publishToNuGet, true) }}:
-                - task: 1ES.PublishNuget@1
-                  displayName: 🟣 Publish packages to NuGet.org
-                  inputs:
-                    useDotNetTask: false
-                    packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg
-                    packageParentPath: $(Build.SourcesDirectory)/artifacts
-                    nuGetFeedType: external
-                    publishVstsFeed: https://api.nuget.org/v3/index.json
-                    # Service connection: https://dev.azure.com/dnceng/internal/_settings/adminservices?resourceId=479fdc43-a27d-4f5f-b2fc-5cf19dce159a
-                    publishFeedCredentials: nuget.org (dotnetframework)
+                    artifactName: Artifacts
+                    targetPath: $(Build.SourcesDirectory)/artifacts
+                # 1ES docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs/nuget-packages
+                # DotNetCoreCLI@2 docs: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/dotnet-core-cli-v2
+                - ${{ if eq(parameters.publishToAzDO, true) }}:
+                  - task: 1ES.PublishNuget@1
+                    displayName: 🟣 Publish packages to AzDO
+                    inputs:
+                      useDotNetTask: true
+                      packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg
+                      packageParentPath: $(Build.SourcesDirectory)/artifacts
+                      publishVstsFeed: ${{ parameters.azDOPublishFeed }}
+                - ${{ if eq(parameters.publishToNuGet, true) }}:
+                  - task: 1ES.PublishNuget@1
+                    displayName: 🟣 Publish packages to NuGet.org
+                    inputs:
+                      useDotNetTask: false
+                      packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg
+                      packageParentPath: $(Build.SourcesDirectory)/artifacts
+                      nuGetFeedType: external
+                      publishVstsFeed: https://api.nuget.org/v3/index.json
+                      # Service connection: https://dev.azure.com/dnceng/internal/_settings/adminservices?resourceId=479fdc43-a27d-4f5f-b2fc-5cf19dce159a
+                      publishFeedCredentials: nuget.org (dotnetframework)


### PR DESCRIPTION
## Summary

I noticed the nightly build tries to run Publish, but it won't actually do anything. This makes it so Publish only runs when there is actually something that needs to be published.

The PR just adds this one line:
```
- ${{ if or(eq(parameters.publishToAzDO, true), eq(parameters.publishToNuGet, true)) }}:
```

But everything has to be indented under it. Nothing was changed in the lines under it. If you compare ignoring whitespace, it is easy to see.

<img width="763" height="201" alt="image" src="https://github.com/user-attachments/assets/7a2e4f22-6b7d-4721-a489-b71ef7f0399e" />
