### PR TITLE
[release/9.0.1xx] Update dependencies to 9.0.82 from dotnet/maui

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,7 @@
     <!--  Begin: Package sources from dotnet-android -->
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-maui -->
+    <add key="darc-pub-dotnet-maui-85704c7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-85704c7a/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-maui -->
     <!--  Begin: Package sources from dotnet-aspire -->
     <!--  End: Package sources from dotnet-aspire -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,9 +30,9 @@
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>10f1ea39eeb1b40b92112d8b8440699879433e55</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-9.0.100" Version="9.0.51">
+    <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-9.0.100" Version="9.0.82">
       <Uri>https://github.com/dotnet/maui</Uri>
-      <Sha>dd13512d027bd88f1ecfe7ed92fcf96e7c2e48f6</Sha>
+      <Sha>85704c7a1c298d99e0bc2256b2e9994e0cd4abf0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="9.0.109-servicing.25368.18">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-sdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
     <MicrosoftNETSdktvOSManifest90100PackageVersion>18.5.9207</MicrosoftNETSdktvOSManifest90100PackageVersion>
     <MicrosoftNETSdkMacCatalystManifest90100PackageVersion>18.5.9207</MicrosoftNETSdkMacCatalystManifest90100PackageVersion>
     <MicrosoftNETSdkmacOSManifest90100PackageVersion>15.5.9207</MicrosoftNETSdkmacOSManifest90100PackageVersion>
-    <MicrosoftNETSdkMauiManifest90100PackageVersion>9.0.51</MicrosoftNETSdkMauiManifest90100PackageVersion>
+    <MicrosoftNETSdkMauiManifest90100PackageVersion>9.0.82</MicrosoftNETSdkMauiManifest90100PackageVersion>
     <MauiWorkloadManifestVersion>$(MicrosoftNETSdkMauiManifest90100PackageVersion)</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</XamarinAndroidWorkloadManifestVersion>
     <XamarinIOSWorkloadManifestVersion>$(MicrosoftNETSdkiOSManifest90100PackageVersion)</XamarinIOSWorkloadManifestVersion>


### PR DESCRIPTION
This pull request updates package dependencies and configuration files to align with the latest versions of the .NET MAUI SDK. The changes include adding a new package source, updating the version of the `Microsoft.NET.Sdk.Maui.Manifest-9.0.100` dependency, and synchronizing related version properties.

### Dependency and configuration updates:

* **Added a new package source for .NET MAUI** in the `NuGet.config` file to reference the `darc-pub-dotnet-maui-85704c7` feed.
* **Updated the `Microsoft.NET.Sdk.Maui.Manifest-9.0.100` dependency version** in `eng/Version.Details.xml` from `9.0.51` to `9.0.82`, along with its associated SHA.
* **Synchronized the `MicrosoftNETSdkMauiManifest90100PackageVersion` property** in `eng/Versions.props` to match the updated version `9.0.82`.