### PR TITLE
Remove .NET 8 Aspire workload

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,8 +10,6 @@
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-maui -->
     <!--  End: Package sources from dotnet-maui -->
-    <!--  Begin: Package sources from dotnet-aspire -->
-    <!--  End: Package sources from dotnet-aspire -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-runtime -->

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -63,10 +63,10 @@ This section details the current process for releasing workloads.
         2. Publish the unstable version to the workloads feed.
         3. The process is different depending on if we're in servicing/golive.
             1. If we're **not** in servicing/golive:
-                - Publish runtime, emsdk, maui, and aspire to the workloads feed.
+                - Publish runtime, emsdk, and maui to the workloads feed.
             2. If we're in servicing/golive:
                 - Only publish maui and the unstable workload set to the workloads feed.
-                - Additionally, create a stable workloads feed and publish the runtime, emsdk, maui, aspire, and stable workload to that feed.
+                - Additionally, create a stable workloads feed and publish the runtime, emsdk, maui, and stable workload to that feed.
                   - To enable this step, the .NET staging pipeline will have to be modified to publish the runtime and emsdk builds to the appropriate workloads channels. Today, that publishing is done in the runtime public build.
         4. Create a vsdrop for each workload.
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,11 +67,6 @@
     <!-- mono workload prerelease version band must match the runtime feature band -->
     <MonoWorkloadFeatureBand>10.0.100$([System.Text.RegularExpressions.Regex]::Match($(MonoWorkloadManifestVersion), `-[A-z]*[\.]*\d*`))</MonoWorkloadFeatureBand>
   </PropertyGroup>
-  <PropertyGroup Label="AspireWorkloads">
-    <AspireFeatureBand>8.0.100</AspireFeatureBand>
-    <MicrosoftNETSdkAspireManifest80100PackageVersion>8.2.2</MicrosoftNETSdkAspireManifest80100PackageVersion>
-    <AspireWorkloadManifestVersion>$(MicrosoftNETSdkAspireManifest80100PackageVersion)</AspireWorkloadManifestVersion>
-  </PropertyGroup>
   <!-- deployment-tools dependencies -->
   <PropertyGroup>
     <MicrosoftDeploymentDotNetReleasesVersion>2.0.0-preview.1.24406.1</MicrosoftDeploymentDotNetReleasesVersion>

--- a/src/Microsoft.NET.Workloads/workloads.props
+++ b/src/Microsoft.NET.Workloads/workloads.props
@@ -25,8 +25,4 @@
     <WorkloadManifest Include="Microsoft.NET.Workload.Mono.ToolChain.net9"    FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
   </ItemGroup>
 
-  <ItemGroup Label="Aspire">
-    <WorkloadManifest Include="Microsoft.NET.Sdk.Aspire" FeatureBand="$(AspireFeatureBand)" Version="$(AspireWorkloadManifestVersion)" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Summary

This simply removes the .NET 8 Aspire workload as it is no longer needed in the workload set.