### PR TITLE
Revert maui and android back to the July release version

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,12 +7,10 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
-    <add key="darc-pub-dotnet-android-be1cab9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-be1cab92/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
     <!--  End: Package sources from dotnet-macios -->
     <!--  Begin: Package sources from dotnet-maui -->
-    <add key="darc-pub-dotnet-maui-85704c7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-85704c7a/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-maui -->
     <!--  Begin: Package sources from dotnet-aspire -->
     <!--  End: Package sources from dotnet-aspire -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,9 +10,9 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>3c298d9f00936d651cc47d221762474e25277672</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.92">
+    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.78">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>be1cab92326783479054e72990da08008e5be819</Sha>
+      <Sha>9abff7703206541fdb83ffa80fe2c2753ad1997b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.iOS.Manifest-9.0.100" Version="18.5.9214">
       <Uri>https://github.com/dotnet/macios</Uri>
@@ -30,9 +30,9 @@
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>0e1a194f0d0e2c0bdd7f36857c87b89aa7c90f98</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-9.0.100" Version="9.0.82">
+    <Dependency Name="Microsoft.NET.Sdk.Maui.Manifest-9.0.100" Version="9.0.51">
       <Uri>https://github.com/dotnet/maui</Uri>
-      <Sha>85704c7a1c298d99e0bc2256b2e9994e0cd4abf0</Sha>
+      <Sha>dd13512d027bd88f1ecfe7ed92fcf96e7c2e48f6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="9.0.302-servicing.25319.7">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-sdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,12 +51,12 @@
   </PropertyGroup>
   <PropertyGroup Label="MauiWorkloads">
     <MauiFeatureBand>9.0.100</MauiFeatureBand>
-    <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.92</MicrosoftNETSdkAndroidManifest90100PackageVersion>
+    <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.78</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <MicrosoftNETSdkiOSManifest90100PackageVersion>18.5.9214</MicrosoftNETSdkiOSManifest90100PackageVersion>
     <MicrosoftNETSdktvOSManifest90100PackageVersion>18.5.9214</MicrosoftNETSdktvOSManifest90100PackageVersion>
     <MicrosoftNETSdkMacCatalystManifest90100PackageVersion>18.5.9214</MicrosoftNETSdkMacCatalystManifest90100PackageVersion>
     <MicrosoftNETSdkmacOSManifest90100PackageVersion>15.5.9214</MicrosoftNETSdkmacOSManifest90100PackageVersion>
-    <MicrosoftNETSdkMauiManifest90100PackageVersion>9.0.82</MicrosoftNETSdkMauiManifest90100PackageVersion>
+    <MicrosoftNETSdkMauiManifest90100PackageVersion>9.0.51</MicrosoftNETSdkMauiManifest90100PackageVersion>
     <MauiWorkloadManifestVersion>$(MicrosoftNETSdkMauiManifest90100PackageVersion)</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</XamarinAndroidWorkloadManifestVersion>
     <XamarinIOSWorkloadManifestVersion>$(MicrosoftNETSdkiOSManifest90100PackageVersion)</XamarinIOSWorkloadManifestVersion>


### PR DESCRIPTION
I had updated the 9.0.3xx branch in order to push workloads into the VS PR. I needed to revert those for the macios release.

I should have just done a private branch to start with but the other changes are already in the 3xx branch so this gets us into the state for the late July macios workloads release.