### PR TITLE
Fixes OutOfMemory exception when hashing large workloads

### DIFF
--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -30,30 +30,10 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
   # See: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash#example-4-compute-the-hash-of-a-string
   $contentStream = [System.IO.MemoryStream]::new()
   $writer = [System.IO.StreamWriter]::new($contentStream)
-  # # Automatically flushes the buffer after every Write call (necessary for workloads such as MAUI with a large number of files).
-  # # See: https://learn.microsoft.com/dotnet/api/system.io.streamwriter.autoflush
-  # $writer.AutoFlush = $true
-  $dropFilePaths = Get-ChildItem -Path $dropDir | Sort-Object | ForEach-Object { $_.FullName }
+  $dropFilePaths = (Get-ChildItem -Path $dropDir | Sort-Object).FullName
   # Hash each file individually, then write the hashes to the stream to create a combined hash.
   $dropFileHashes = (Get-FileHash -Path $dropFilePaths).Hash
   $null = $dropFileHashes | ForEach-Object { $writer.Write($_) }
-  # foreach ($dropFile in $dropFiles)
-  # {
-  #   try {
-  #     # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
-  #     # $fileContentLines = Get-Content -Path $dropFile.FullName -Encoding ASCII -ErrorAction Stop
-  #     # $null = $fileContentLines | ForEach-Object { $writer.WriteLine($_) }
-
-  #     $fileBytes = [System.IO.File]::ReadAllBytes($dropFile.FullName)
-  #     # $null = $writer.BaseStream.Write($fileBytes, 0, $fileBytes.Length)
-  #     $contentStream = [System.IO.MemoryStream]::new($fileBytes)
-  #   } catch {
-  #     Write-Host "Error: $($_.Exception.Message)"
-  #     Write-Host "Type: $($_.Exception.GetType().FullName)"
-  #     Write-Host "File: $($dropFile.FullName)"
-  #     continue
-  #   }
-  # }
   $writer.Flush()
   $contentStream.Position = 0
   $dropHash = (Get-FileHash -InputStream $contentStream).Hash

--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -28,8 +28,8 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
   # Hash the files within the drop folder to create a unique identifier that represents this workload drop.
   # Example: 1E3EA4FE202394037253F57436A6EAD5DE1359792B618B9072014A98563A30FB
   # See: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash#example-4-compute-the-hash-of-a-string
-  $contentStream = [System.IO.MemoryStream]::new()
-  $writer = [System.IO.StreamWriter]::new($contentStream)
+  # $contentStream = [System.IO.MemoryStream]::new()
+  # $writer = [System.IO.StreamWriter]::new($contentStream)
   # # Automatically flushes the buffer after every Write call (necessary for workloads such as MAUI with a large number of files).
   # # See: https://learn.microsoft.com/dotnet/api/system.io.streamwriter.autoflush
   # $writer.AutoFlush = $true
@@ -42,7 +42,8 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
       # $null = $fileContentLines | ForEach-Object { $writer.WriteLine($_) }
 
       $fileBytes = [System.IO.File]::ReadAllBytes($dropFile.FullName)
-      $null = $writer.BaseStream.Write($fileBytes, 0, $fileBytes.Length)
+      # $null = $writer.BaseStream.Write($fileBytes, 0, $fileBytes.Length)
+      $contentStream = [System.IO.MemoryStream]::new($fileBytes)
     } catch {
       Write-Host "Error: $($_.Exception.Message)"
       Write-Host "Type: $($_.Exception.GetType().FullName)"
@@ -50,10 +51,10 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
       continue
     }
   }
-  $writer.Flush()
+  # $writer.Flush()
   $contentStream.Position = 0
   $dropHash = (Get-FileHash -InputStream $contentStream).Hash
-  $writer.Close()
+  # $writer.Close()
 
   $vsDropName = "Products/dotnet/workloads/$assemblyName/$dropHash"
   # Reads the first line out of the .metadata file in the workload's output folder and sets it to the workload version.

--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -38,14 +38,17 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
   {
     try {
       # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
-      $fileContentLines = Get-Content -Path $dropFile.FullName -Encoding ASCII -ErrorAction Stop
+      # $fileContentLines = Get-Content -Path $dropFile.FullName -Encoding ASCII -ErrorAction Stop
+      # $null = $fileContentLines | ForEach-Object { $writer.WriteLine($_) }
+
+      $fileBytes = [System.IO.File]::ReadAllBytes($dropFile.FullName)
+      $null = $writer.BaseStream.Write($fileBytes, 0, $fileBytes.Length)
     } catch {
       Write-Host "Error: $($_.Exception.Message)"
       Write-Host "Type: $($_.Exception.GetType().FullName)"
       Write-Host "File: $($dropFile.FullName)"
       continue
     }
-    $null = $fileContentLines | ForEach-Object { $writer.WriteLine($_) }
   }
   $writer.Flush()
   $contentStream.Position = 0
@@ -85,7 +88,7 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
     }
   }
 
-  Write-Host '⚠︎ After upload, your workload drop will be available at:'
+  Write-Host '!!! After upload, your workload drop will be available at:'
   Write-Host "https://devdiv.visualstudio.com/_apps/hub/ms-vscs-artifact.build-tasks.drop-hub-group-explorer-hub?name=$vsDropName"
 }
 

--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -34,8 +34,12 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
   # See: https://learn.microsoft.com/dotnet/api/system.io.streamwriter.autoflush
   $writer.AutoFlush = $true
   $dropFiles = Get-ChildItem -Path $dropDir | Sort-Object
-  # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
-  $null = $dropFiles | Get-Content -Encoding ASCII -Raw | ForEach-Object { $writer.Write($_) }
+  foreach ($dropFile in $dropFiles)
+  {
+    # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
+    $fileContent = Get-Content -Path $dropFile.FullName -Encoding ASCII -Raw
+    $null = $writer.Write($fileContent)
+  }
   $writer.Flush()
   $contentStream.Position = 0
   $dropHash = (Get-FileHash -InputStream $contentStream).Hash

--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -30,22 +30,22 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
   # See: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash#example-4-compute-the-hash-of-a-string
   $contentStream = [System.IO.MemoryStream]::new()
   $writer = [System.IO.StreamWriter]::new($contentStream)
-  # Automatically flushes the buffer after every Write call (necessary for workloads such as MAUI with a large number of files).
-  # See: https://learn.microsoft.com/dotnet/api/system.io.streamwriter.autoflush
-  $writer.AutoFlush = $true
+  # # Automatically flushes the buffer after every Write call (necessary for workloads such as MAUI with a large number of files).
+  # # See: https://learn.microsoft.com/dotnet/api/system.io.streamwriter.autoflush
+  # $writer.AutoFlush = $true
   $dropFiles = Get-ChildItem -Path $dropDir | Sort-Object
   foreach ($dropFile in $dropFiles)
   {
     try {
       # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
-      $fileContent = Get-Content -Path $dropFile.FullName -Encoding ASCII -Raw -ErrorAction Stop
+      $fileContentLines = Get-Content -Path $dropFile.FullName -Encoding ASCII -ErrorAction Stop
     } catch {
       Write-Host "Error: $($_.Exception.Message)"
       Write-Host "Type: $($_.Exception.GetType().FullName)"
       Write-Host "File: $($dropFile.FullName)"
       continue
     }
-    $null = $writer.Write($fileContent)
+    $null = $fileContentLines | ForEach-Object { $writer.WriteLine($_) }
   }
   $writer.Flush()
   $contentStream.Position = 0

--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -38,7 +38,7 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
   {
     try {
       # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
-      $fileContent = Get-Content -Path $dropFile.FullName -Encoding ASCII -Raw
+      $fileContent = Get-Content -Path $dropFile.FullName -Encoding ASCII -Raw -ErrorAction Stop
     } catch {
       Write-Host "Error: $($_.Exception.Message)"
       Write-Host "Type: $($_.Exception.GetType().FullName)"

--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -30,6 +30,9 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
   # See: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash#example-4-compute-the-hash-of-a-string
   $contentStream = [System.IO.MemoryStream]::new()
   $writer = [System.IO.StreamWriter]::new($contentStream)
+  # Automatically flushes the buffer after every Write call (necessary for workloads such as MAUI with a large number of files).
+  # See: https://learn.microsoft.com/dotnet/api/system.io.streamwriter.autoflush
+  $writer.AutoFlush = $true
   $dropFiles = Get-ChildItem -Path $dropDir | Sort-Object
   # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
   $null = $dropFiles | Get-Content -Encoding ASCII -Raw | ForEach-Object { $writer.Write($_) }

--- a/eng/create-workload-drops.ps1
+++ b/eng/create-workload-drops.ps1
@@ -36,8 +36,15 @@ Get-ChildItem -Path $workloadDropPath -Directory | ForEach-Object {
   $dropFiles = Get-ChildItem -Path $dropDir | Sort-Object
   foreach ($dropFile in $dropFiles)
   {
-    # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
-    $fileContent = Get-Content -Path $dropFile.FullName -Encoding ASCII -Raw
+    try {
+      # Note: We're using ASCII because when testing between PS 5.1 and PS 7.5, this would result in the same hash. Other encodings arrived at different hashes.
+      $fileContent = Get-Content -Path $dropFile.FullName -Encoding ASCII -Raw
+    } catch {
+      Write-Host "Error: $($_.Exception.Message)"
+      Write-Host "Type: $($_.Exception.GetType().FullName)"
+      Write-Host "File: $($dropFile.FullName)"
+      continue
+    }
     $null = $writer.Write($fileContent)
   }
   $writer.Flush()


### PR DESCRIPTION
## Summary

When creating this hashing method originally, I only had a subset of the number of workloads we now use with this pipeline. When Android was added, hashing the *packs* drop resulted in a System.OutOfMemory exception.

The algorithm was pulling out the content of the workload drop as ASCII and writing it to a stream. Then, it created a hash of all of the content combined from the workload drop. Doing this process for the Android drop (which is 600+ MBs) would cause this exception.

To avoid this, I instead hash each file individually. Then, I write each individual file hash to the stream and hash that. So, it creates a "hash of hashes". Since this hash is only used as a unique identifier for workload drop uploading for VS insertions, it doesn't matter if this hash is "less accurate" in this way. It won't cause any problems since the only purpose is to attempt to not upload duplicate workloads for VS insertions. Anything is better than throwing OutOfMemory exceptions.

If you look through the commits, I tried several other ways of doing this (and debugging it), but none of them worked. This "hash of hashes" solution would only have issues if an individual file was too large. AFAIK, the workloads don't have large enough individual files for this to be a problem.

Lastly, I changed the `⚠︎ After upload` text since the AzDO logs don't render it properly. Triple exclamation points is just fine for searching. In the logs, `⚠︎` was rendering as:

> âs ï,Z After upload, your workload drop will be available at: