### PR TITLE
Set run name to use source branch's commit message

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -109,18 +109,6 @@ variables:
 # DotNet-DevDiv-Insertion-Workflow-Variables provides: dn-bot-devdiv-drop-rw-code-rw
 # https://dnceng.visualstudio.com/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=33&path=DotNet-DevDiv-Insertion-Workflow-Variables
 - group: DotNet-DevDiv-Insertion-Workflow-Variables
-- name: ref
-  value: $[ resources.repositories.source.ref ]
-- name: name
-  value: $[ resources.repositories.source.name ]
-- name: id
-  value: $[ resources.repositories.source.id ]
-- name: type
-  value: $[ resources.repositories.source.type ]
-- name: url
-  value: $[ resources.repositories.source.url ]
-- name: version
-  value: $[ resources.repositories.source.version ]
 
 resources:
   repositories:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -4,6 +4,10 @@
 trigger: none
 pr: none
 
+# Required to set a custom run name within workload-checkout.yml.
+# See: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pipeline
+appendCommitMessageToRunName: false
+
 parameters:
 - name: sourceBranch
   displayName: 🚩 Source Branch 🚩
@@ -105,6 +109,18 @@ variables:
 # DotNet-DevDiv-Insertion-Workflow-Variables provides: dn-bot-devdiv-drop-rw-code-rw
 # https://dnceng.visualstudio.com/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=33&path=DotNet-DevDiv-Insertion-Workflow-Variables
 - group: DotNet-DevDiv-Insertion-Workflow-Variables
+- name: ref
+  value: $[ resources.repositories.source.ref ]
+- name: name
+  value: $[ resources.repositories.source.name ]
+- name: id
+  value: $[ resources.repositories.source.id ]
+- name: type
+  value: $[ resources.repositories.source.type ]
+- name: url
+  value: $[ resources.repositories.source.url ]
+- name: version
+  value: $[ resources.repositories.source.version ]
 
 resources:
   repositories:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -10,7 +10,7 @@ appendCommitMessageToRunName: false
 
 parameters:
 - name: sourceBranch
-  displayName: 🚩 Source Branch 🚩
+  displayName: 🚩 Source branch 🚩
   type: string
 
 - name: dividerAzDO
@@ -35,7 +35,7 @@ parameters:
   type: boolean
   default: false
 - name: vsTopicBranch
-  displayName: 'VS Topic Branch [default: temp/{team}/{target}/yyyy-MM]'
+  displayName: 'VS topic branch [default: temp/{team}/{target}/yyyy-MM]'
   type: string
   default: '|default|'
 # TODO: This needs fixed for single-entry values.
@@ -78,7 +78,7 @@ parameters:
   type: boolean
   default: false
 - name: usePreComponentsForVSInsertion
-  displayName: Use Preview Components for VS insertion
+  displayName: Use preview components for VS insertion
   type: boolean
   default: false
 - name: includeNonShippingWorkloads

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -157,7 +157,6 @@ extends:
           workloadDropNames: ${{ parameters.workloadDropNames }}
           primaryVsInsertionBranches: ${{ parameters.primaryVsInsertionBranches }}
           secondaryVsInsertionBranches: ${{ parameters.secondaryVsInsertionBranches }}
-          sourceBranch: ${{ parameters.sourceBranch }}
     - ${{ if or(eq(parameters.publishToAzDO, true), eq(parameters.publishToNuGet, true)) }}:
       - stage: Publish
         displayName: Publish

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -157,6 +157,7 @@ extends:
           workloadDropNames: ${{ parameters.workloadDropNames }}
           primaryVsInsertionBranches: ${{ parameters.primaryVsInsertionBranches }}
           secondaryVsInsertionBranches: ${{ parameters.secondaryVsInsertionBranches }}
+          sourceBranch: ${{ parameters.sourceBranch }}
     - ${{ if or(eq(parameters.publishToAzDO, true), eq(parameters.publishToNuGet, true)) }}:
       - stage: Publish
         displayName: Publish

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -4,7 +4,7 @@
 trigger: none
 pr: none
 
-# Required to set a custom run name within workload-checkout.yml.
+# Required to set a custom run name within workload-build.yml.
 # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pipeline
 appendCommitMessageToRunName: false
 

--- a/eng/pipelines/public.yml
+++ b/eng/pipelines/public.yml
@@ -38,13 +38,13 @@ variables:
 stages:
 - template: /eng/pipelines/templates/stages/workload-public-build.yml@self
   parameters:
-    sourceBranch: main
-    engBranch: self
+    sourceBranchAlias: main
+    engBranchAlias: self
 - template: /eng/pipelines/templates/stages/workload-public-build.yml@self
   parameters:
-    sourceBranch: release8
-    engBranch: self
+    sourceBranchAlias: release8
+    engBranchAlias: self
 - template: /eng/pipelines/templates/stages/workload-public-build.yml@self
   parameters:
-    sourceBranch: release9
-    engBranch: self
+    sourceBranchAlias: release9
+    engBranchAlias: self

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -35,9 +35,10 @@ jobs:
         image: 1es-windows-2022
         os: windows
       variables:
-        # Build.BuildNumber is changed to set the run name to contain the source branch commit message.
-        # Therefore, Build.BuildNumber is stored to a variable since the original value is needed for Arcade as the OfficialBuildId property.
-        OfficialBuildId: $(Build.BuildNumber)
+      # Build.BuildNumber is changed to set the run name to contain the source branch commit message.
+      # Therefore, Build.BuildNumber is stored to a variable since the original value is needed for Arcade as the OfficialBuildId property.
+      - name: OfficialBuildId
+        value: $(Build.BuildNumber)
       steps:
       - template: /eng/pipelines/templates/steps/workload-checkout.yml@self
         parameters:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -34,25 +34,23 @@ jobs:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
-      variables:
-      # Build.BuildNumber is changed to set the run name to contain the source branch commit message.
-      # Therefore, Build.BuildNumber is stored to a variable since the original value is needed for Arcade as the OfficialBuildId property.
-      # Using a runtime expression $[] allows this to be resolved prior to being changed.
-      - name: OfficialBuildId
-        value: $[ variables.Build.BuildNumber ]
       steps:
       - template: /eng/pipelines/templates/steps/workload-checkout.yml@self
         parameters:
           sourceBranchAlias: source
           engBranchAlias: self
       # Sets the run name to use the source branch commit message.
+      # Also, sets the OfficialBuildId variable to the original Build.BuildNumber for use in Arcade.
       # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
       - powershell: |
           # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
-          Write-Host "OfficialBuildId: $(OfficialBuildId)"
+          Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
           $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
           Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
         displayName: 🟣 Set run name via source branch commit message
+      - powershell: |
+          Write-Host "OfficialBuildId: $(OfficialBuildId)"
+        displayName: 🟣 OfficialBuildId
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -39,8 +39,7 @@ jobs:
       # Therefore, Build.BuildNumber is stored to a variable since the original value is needed for Arcade as the OfficialBuildId property.
       # Using a runtime expression $[] allows this to be resolved prior to being changed.
       - name: OfficialBuildId
-        # value: $[variables.Build.BuildNumber]
-        value: ${{ variables.Build.BuildNumber }}
+        value: $[ variables.Build.BuildNumber ]
       steps:
       - template: /eng/pipelines/templates/steps/workload-checkout.yml@self
         parameters:
@@ -50,6 +49,7 @@ jobs:
       # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
       - powershell: |
           # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
+          Write-Host "OfficialBuildId: $(OfficialBuildId)"
           $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
           Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
         displayName: 🟣 Set run name via source branch commit message

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -39,14 +39,20 @@ jobs:
       # Therefore, Build.BuildNumber is stored to a variable since the original value is needed for Arcade as the OfficialBuildId property.
       # Using a runtime expression $[] allows this to be resolved prior to being changed.
       - name: OfficialBuildId
-        value: $[variables.Build.BuildNumber]
+        # value: $[variables.Build.BuildNumber]
+        value: ${{ variables.Build.BuildNumber }}
       steps:
       - template: /eng/pipelines/templates/steps/workload-checkout.yml@self
         parameters:
           sourceBranchAlias: source
           engBranchAlias: self
-          useSourceCommitMessageRunName: true
-          sourceBranch: ${{ parameters.sourceBranch }}
+      # Sets the run name to use the source branch commit message.
+      # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
+      - powershell: |
+          # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
+          $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
+          Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
+        displayName: 🟣 Set run name via source branch commit message
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -43,9 +43,10 @@ jobs:
       steps:
       - template: /eng/pipelines/templates/steps/workload-checkout.yml@self
         parameters:
-          sourceBranch: source
-          engBranch: self
+          sourceBranchAlias: source
+          engBranchAlias: self
           useSourceCommitMessageRunName: true
+          sourceBranch: ${{ parameters.sourceBranch }}
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -37,6 +37,7 @@ jobs:
       variables:
       # Build.BuildNumber is changed to set the run name to contain the source branch commit message.
       # Therefore, Build.BuildNumber is stored to a variable since the original value is needed for Arcade as the OfficialBuildId property.
+      # Using a runtime expression $[] allows this to be resolved prior to being changed.
       - name: OfficialBuildId
         value: $[variables.Build.BuildNumber]
       steps:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -34,11 +34,16 @@ jobs:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
+      variables:
+        # Build.BuildNumber is changed to set the run name to contain the source branch commit message.
+        # Therefore, Build.BuildNumber is stored to a variable since the original value is needed for Arcade as the OfficialBuildId property.
+        OfficialBuildId: $(Build.BuildNumber)
       steps:
       - template: /eng/pipelines/templates/steps/workload-checkout.yml@self
         parameters:
           sourceBranch: source
           engBranch: self
+          useSourceCommitMessageRunName: true
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion
@@ -65,18 +70,9 @@ jobs:
           /p:DotNetSignType=$(_SignType)
           /p:TeamName=$(_TeamName)
           /p:DotNetPublishUsingPipelines=true
-          /p:OfficialBuildId=$(Build.BuildNumber)
+          /p:OfficialBuildId=$(OfficialBuildId)
           /p:StabilizePackageVersion=${{ parameters.stabilizePackageVersion }}
         displayName: 🟣 Build solution
-      # Sets the run name to use the source commit message.
-      # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
-      # Note: This must be performed AFTER the build, as Arcade requires the default run number for the OfficialBuildId property.
-      - powershell: |
-          # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
-          $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
-          Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
-        displayName: 🟣 Set run name from source commit message
-        condition: always()
 
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         # The variables comprised of workloadShortName and workloadType are set during create-workload-drops.ps1 in Microsoft.NET.Workloads.Vsman.csproj.

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -39,6 +39,15 @@ jobs:
         parameters:
           sourceBranch: source
           engBranch: self
+          useSourceCommitMessageRunName: true
+      - bash: |
+          echo "name = $(name)"
+          echo "ref = $(ref)"
+          echo "id = $(id)"
+          echo "type = $(type)"
+          echo "url = $(url)"
+          echo "version = $(version)"
+        displayName: 🟣 Display repository variables
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -48,6 +48,10 @@ jobs:
           echo "url = $(url)"
           echo "version = $(version)"
         displayName: 🟣 Display repository variables
+        condition: always()
+      - powershell: 'Get-ChildItem env:'
+        displayName: 🟣 List Environment Variables
+        condition: always()
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -39,19 +39,6 @@ jobs:
         parameters:
           sourceBranch: source
           engBranch: self
-          useSourceCommitMessageRunName: true
-      - bash: |
-          echo "name = $(name)"
-          echo "ref = $(ref)"
-          echo "id = $(id)"
-          echo "type = $(type)"
-          echo "url = $(url)"
-          echo "version = $(version)"
-        displayName: 🟣 Display repository variables
-        condition: always()
-      - powershell: 'Get-ChildItem env:'
-        displayName: 🟣 List Environment Variables
-        condition: always()
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion
@@ -81,6 +68,15 @@ jobs:
           /p:OfficialBuildId=$(Build.BuildNumber)
           /p:StabilizePackageVersion=${{ parameters.stabilizePackageVersion }}
         displayName: 🟣 Build solution
+      # Sets the run name to use the source commit message.
+      # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
+      # Note: This must be performed AFTER the build, as Arcade requires the default run number for the OfficialBuildId property.
+      - powershell: |
+          # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
+          $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
+          Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
+        displayName: 🟣 Set run name from source commit message
+        condition: always()
 
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         # The variables comprised of workloadShortName and workloadType are set during create-workload-drops.ps1 in Microsoft.NET.Workloads.Vsman.csproj.

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -43,14 +43,11 @@ jobs:
       # Also, sets the OfficialBuildId variable to the original Build.BuildNumber for use in Arcade.
       # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
       - powershell: |
-          # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
           Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
+          # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
           $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
           Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
         displayName: 🟣 Set run name via source branch commit message
-      - powershell: |
-          Write-Host "OfficialBuildId: $(OfficialBuildId)"
-        displayName: 🟣 OfficialBuildId
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -38,7 +38,7 @@ jobs:
       # Build.BuildNumber is changed to set the run name to contain the source branch commit message.
       # Therefore, Build.BuildNumber is stored to a variable since the original value is needed for Arcade as the OfficialBuildId property.
       - name: OfficialBuildId
-        value: $(Build.BuildNumber)
+        value: $[variables.Build.BuildNumber]
       steps:
       - template: /eng/pipelines/templates/steps/workload-checkout.yml@self
         parameters:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -44,8 +44,10 @@ jobs:
       # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
       - powershell: |
           Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
-          # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
-          $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
+          # Keep only valid characters. Invalid characters include: " / : < > \ | ? @ *
+          # Also, strip any trailing '.' characters as those are invalid too.
+          # Lastly, truncate to 255 max characters: 241 = 255 - 14 (for build number and delimiter, ex: 20250910.13 • )
+          $commitMessage = ("$(git log -1 --pretty=%s)".Trim() -replace '["\/:<>\\|?@*]|\.{1,}$', '').Substring(0, 241)
           Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
         displayName: 🟣 Set run name via source branch commit message
       - ${{ if eq(parameters.createVSInsertion, true) }}:

--- a/eng/pipelines/templates/stages/workload-public-build.yml
+++ b/eng/pipelines/templates/stages/workload-public-build.yml
@@ -1,13 +1,13 @@
 parameters:
-  sourceBranch: self
-  engBranch: eng
+  sourceBranchAlias: self
+  engBranchAlias: eng
 
 stages:
-- stage: Build_${{ parameters.sourceBranch }}
-  displayName: Build ${{ parameters.sourceBranch }}
+- stage: Build_${{ parameters.sourceBranchAlias }}
+  displayName: Build ${{ parameters.sourceBranchAlias }}
   dependsOn: []
   jobs:
-  - template: /eng/common/templates/job/job.yml@${{ parameters.sourceBranch }}
+  - template: /eng/common/templates/job/job.yml@${{ parameters.sourceBranchAlias }}
     parameters:
       name: buildRepo
       displayName: Build Repo
@@ -17,12 +17,12 @@ stages:
       artifacts:
         publish:
           logs:
-            name: Logs_${{ parameters.sourceBranch }}
+            name: Logs_${{ parameters.sourceBranchAlias }}
       steps:
-      - template: /eng/pipelines/templates/steps/workload-checkout.yml@${{ parameters.engBranch }}
+      - template: /eng/pipelines/templates/steps/workload-checkout.yml@${{ parameters.engBranchAlias }}
         parameters:
-          sourceBranch: ${{ parameters.sourceBranch }}
-          engBranch: ${{ parameters.engBranch }}
+          sourceBranchAlias: ${{ parameters.sourceBranchAlias }}
+          engBranchAlias: ${{ parameters.engBranchAlias }}
       - powershell: >-
           eng/common/build.ps1
           -restore -build -pack -ci -msbuildEngine vs

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -1,8 +1,6 @@
 parameters:
   sourceBranchAlias: self
   engBranchAlias: eng
-  useSourceCommitMessageRunName: false
-  sourceBranch: main
 
 steps:
 # For checkout mechanics, see:
@@ -13,16 +11,6 @@ steps:
   path: source-branch
   workspaceRepo: true
   displayName: 🟣 Checkout source branch
-# Sets the run name to use the source branch commit message.
-# See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
-- ${{ if eq(parameters.useSourceCommitMessageRunName, true) }}:
-  - powershell: |
-      # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
-      Write-Host "$(git branch --show-current)"
-      $commitMessage = "$(git log ${{ parameters.sourceBranch }} -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
-      Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
-    displayName: 🟣 Set run name via source branch commit message
-    condition: always()
 # There is a warning when performing the second checkout, ##[warning]Unable move and reuse existing repository to required location.
 # This happens because both checkouts are of the same repository, thus have the same path of: D:\a\_work\1\s\workload-versions
 # The first checkout deletes this directory. To avoid the warning, simply create the directory beforehand.

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -16,8 +16,9 @@ steps:
 # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
 - ${{ if eq(parameters.useSourceCommitMessageRunName, true) }}:
   - powershell: |
-      $commitMessage = "$(git log -1 --pretty=%s)".Trim()
-      Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
+      # Remove all non-alphanumeric characters and truncate to 255 max characters (255 - 14 for number and preamble) to avoid run name issues.
+      $commitMessage = ("$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9]', '').Substring(0, 241)
+      Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) - $commitMessage"
     displayName: 🟣 Set run name from source commit message
 # There is a warning when performing the second checkout, ##[warning]Unable move and reuse existing repository to required location.
 # This happens because both checkouts are of the same repository, thus have the same path of: D:\a\_work\1\s\workload-versions

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -18,6 +18,7 @@ steps:
 - ${{ if eq(parameters.useSourceCommitMessageRunName, true) }}:
   - powershell: |
       # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
+      Write-Host "$(git branch --show-current)"
       $commitMessage = "$(git log ${{ parameters.sourceBranch }} -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
       Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
     displayName: 🟣 Set run name via source branch commit message

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -1,7 +1,6 @@
 parameters:
   sourceBranch: self
   engBranch: eng
-  useSourceCommitMessageRunName: false
 
 steps:
 # For checkout mechanics, see:
@@ -12,14 +11,6 @@ steps:
   path: source-branch
   workspaceRepo: true
   displayName: 🟣 Checkout source branch
-# Sets the run name to use the source commit message.
-# See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
-- ${{ if eq(parameters.useSourceCommitMessageRunName, true) }}:
-  - powershell: |
-      # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
-      $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
-      Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) - $commitMessage"
-    displayName: 🟣 Set run name from source commit message
 # There is a warning when performing the second checkout, ##[warning]Unable move and reuse existing repository to required location.
 # This happens because both checkouts are of the same repository, thus have the same path of: D:\a\_work\1\s\workload-versions
 # The first checkout deletes this directory. To avoid the warning, simply create the directory beforehand.

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -1,6 +1,7 @@
 parameters:
   sourceBranch: self
   engBranch: eng
+  useSourceCommitMessageRunName: false
 
 steps:
 # For checkout mechanics, see:
@@ -11,6 +12,13 @@ steps:
   path: source-branch
   workspaceRepo: true
   displayName: 🟣 Checkout source branch
+# Sets the run name to use the source commit message.
+# See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
+- ${{ if eq(parameters.useSourceCommitMessageRunName, true) }}:
+  - powershell: |
+      $commitMessage = "$(git log -1 --pretty=%s)".Trim()
+      Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
+    displayName: 🟣 Set run name from source commit message
 # There is a warning when performing the second checkout, ##[warning]Unable move and reuse existing repository to required location.
 # This happens because both checkouts are of the same repository, thus have the same path of: D:\a\_work\1\s\workload-versions
 # The first checkout deletes this directory. To avoid the warning, simply create the directory beforehand.

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -1,14 +1,15 @@
 parameters:
-  sourceBranch: self
-  engBranch: eng
+  sourceBranchAlias: self
+  engBranchAlias: eng
   useSourceCommitMessageRunName: false
+  sourceBranch: main
 
 steps:
 # For checkout mechanics, see:
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-checkout?view=azure-pipelines
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-- checkout: ${{ parameters.sourceBranch }}
+- checkout: ${{ parameters.sourceBranchAlias }}
   path: source-branch
   workspaceRepo: true
   displayName: 🟣 Checkout source branch
@@ -29,7 +30,7 @@ steps:
 # To resolve this, we split on '/' and take the last element, which will always be the repository name only.
 - powershell: New-Item -Path "$(Agent.BuildDirectory)\s" -Name "$('$(Build.Repository.Name)' -Split '/' | Select-Object -Last 1)" -ItemType Directory
   displayName: 🟣 [Workaround] Create checkout directory
-- checkout: ${{ parameters.engBranch }}
+- checkout: ${{ parameters.engBranchAlias }}
   path: eng-branch
   displayName: 🟣 Checkout eng branch
 # The \* is required for the Exclude to work properly.

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -1,6 +1,7 @@
 parameters:
   sourceBranch: self
   engBranch: eng
+  useSourceCommitMessageRunName: false
 
 steps:
 # For checkout mechanics, see:
@@ -11,6 +12,15 @@ steps:
   path: source-branch
   workspaceRepo: true
   displayName: 🟣 Checkout source branch
+# Sets the run name to use the source branch commit message.
+# See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
+- ${{ if eq(parameters.useSourceCommitMessageRunName, true) }}:
+  - powershell: |
+      # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
+      $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
+      Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
+    displayName: 🟣 Set run name via source branch commit message
+    condition: always()
 # There is a warning when performing the second checkout, ##[warning]Unable move and reuse existing repository to required location.
 # This happens because both checkouts are of the same repository, thus have the same path of: D:\a\_work\1\s\workload-versions
 # The first checkout deletes this directory. To avoid the warning, simply create the directory beforehand.

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -20,6 +20,7 @@ steps:
       $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
       Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
     displayName: 🟣 Set run name via source branch commit message
+    workingDirectory: $(Agent.BuildDirectory)\source-branch
     condition: always()
 # There is a warning when performing the second checkout, ##[warning]Unable move and reuse existing repository to required location.
 # This happens because both checkouts are of the same repository, thus have the same path of: D:\a\_work\1\s\workload-versions

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -16,8 +16,8 @@ steps:
 # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
 - ${{ if eq(parameters.useSourceCommitMessageRunName, true) }}:
   - powershell: |
-      # Remove all non-alphanumeric characters and truncate to 255 max characters (255 - 14 for number and preamble) to avoid run name issues.
-      $commitMessage = ("$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9]', '').Substring(0, 241)
+      # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
+      $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
       Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) - $commitMessage"
     displayName: 🟣 Set run name from source commit message
 # There is a warning when performing the second checkout, ##[warning]Unable move and reuse existing repository to required location.

--- a/eng/pipelines/templates/steps/workload-checkout.yml
+++ b/eng/pipelines/templates/steps/workload-checkout.yml
@@ -17,10 +17,9 @@ steps:
 - ${{ if eq(parameters.useSourceCommitMessageRunName, true) }}:
   - powershell: |
       # Keep only alphanumeric characters (and space) and truncate to 255 max characters (255 - 14 for build number and delimiter) to avoid run name issues.
-      $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
+      $commitMessage = "$(git log ${{ parameters.sourceBranch }} -1 --pretty=%s)".Trim() -replace '[^a-zA-Z0-9 ]', '' | Select-Object -First 241
       Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
     displayName: 🟣 Set run name via source branch commit message
-    workingDirectory: $(Agent.BuildDirectory)\source-branch
     condition: always()
 # There is a warning when performing the second checkout, ##[warning]Unable move and reuse existing repository to required location.
 # This happens because both checkouts are of the same repository, thus have the same path of: D:\a\_work\1\s\workload-versions


### PR DESCRIPTION
## Summary

When running the official build, the run name will always show the last commit message from the `eng` branch, which is not desired. What is ideal is showing the last commit message from the provided 'source branch' when the pipeline is ran. I figured this would be pretty simple and straightforward to set, but it was not. 😭

## Details
When running a build, Azure Pipelines will, [by default](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number?view=azure-devops), use this format for the run name:

```
#$(Date:yyyyMMdd).$(Rev:r) • $(Build.SourceVersionMessage)
```

We actually want the `$(Build.SourceVersionMessage)` to be from the 'source branch' and not the `eng` branch. But, this value is not configurable. Updating the run name would be simple if there was just a "display name" value for this. However, there is not. Instead, it works as such:

- Always shows a `#` as the first character no matter the settings.
- The `$(Date:yyyyMMdd).$(Rev:r)` portion is actually the `$(Build.BuildNumber)` value.
- The ` • $(Build.SourceVersionMessage)` portion is actually shown via a boolean [appendCommitMessageToRunName](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pipeline?view=azure-pipelines#pipeline-stages), which is set to `true` by default.

The only way to change this run name is by doing the following:
- Set [appendCommitMessageToRunName](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pipeline?view=azure-pipelines#pipeline-stages) to `false` for the pipeline so the default commit message is no longer appended to the run name.
- Update the `$(Build.BuildNumber)` via the [logging command](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#updatebuildnumber-override-the-automatically-generated-build-number), `build.updatebuildnumber`.

This allows you to "fully customize" the run name as long as `Build.BuildNumber` does not:
-  contains invalid character(s)
    - `Characters which are not allowed include '"', '/', ':', '<', '>', '\', '|', '?', '@', and '*'.`
- is too long
    - The maximum length of a build number is 255 characters.
- or ends with '.'. 

So, I've been forced to clean the commit message from the source branch when I gather it to adhere to these requirements. This normally doesn't require this level of scrutiny when the default `appendCommitMessageToRunName` is used.

Another problem arose. Apparently, Arcade uses `$(Build.BuildNumber)` in various places. Generally, it is set to the `OfficialBuildId` property. We send that value here when we build, so I simply save the original value to a `OfficialBuildId` variable, and then use that when we build. That resolved the build issue.

The other Arcade issue is that the 'Publish Assets' stage has the use of `$(Build.BuildNumber)` hard-coded to be the `OfficialBuildId` property. To solve that, I've created a [PR for Arcade](https://github.com/dotnet/arcade/pull/16122) to allow setting the `OfficialBuildId` property in 'Publish Assets' stage via the jobs.yml parameters. This change is required prior to merging this PR.