### PR TITLE
Update workload manifests with version conditions for 9/10

### DIFF
--- a/src/Microsoft.NET.Workloads/workloads.props
+++ b/src/Microsoft.NET.Workloads/workloads.props
@@ -4,8 +4,8 @@
     <WorkloadManifest Include="Microsoft.NET.Workload.Emscripten.Current" FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
     <WorkloadManifest Include="Microsoft.NET.Workload.Emscripten.net6"    FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
     <WorkloadManifest Include="Microsoft.NET.Workload.Emscripten.net7"    FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
-    <WorkloadManifest Include="Microsoft.NET.Workload.Emscripten.net8"    FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
-    <WorkloadManifest Include="Microsoft.NET.Workload.Emscripten.net9"    FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
+    <WorkloadManifest Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(VersionMajor)', '9'))" Include="Microsoft.NET.Workload.Emscripten.net8"    FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
+    <WorkloadManifest Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(VersionMajor)', '10'))" Include="Microsoft.NET.Workload.Emscripten.net9"    FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
   </ItemGroup>
 
   <ItemGroup Label="Maui">
@@ -21,8 +21,8 @@
     <WorkloadManifest Include="Microsoft.NET.Workload.Mono.ToolChain.Current" FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
     <WorkloadManifest Include="Microsoft.NET.Workload.Mono.ToolChain.net6"    FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
     <WorkloadManifest Include="Microsoft.NET.Workload.Mono.ToolChain.net7"    FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
-    <WorkloadManifest Include="Microsoft.NET.Workload.Mono.ToolChain.net8"    FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
-    <WorkloadManifest Include="Microsoft.NET.Workload.Mono.ToolChain.net9"    FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
+    <WorkloadManifest Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(VersionMajor)', '9'))" Include="Microsoft.NET.Workload.Mono.ToolChain.net8"    FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
+    <WorkloadManifest Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(VersionMajor)', '10'))" Include="Microsoft.NET.Workload.Mono.ToolChain.net9"    FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We're incorrectly including the .net8 workload manifest in the 8.0.4xx workload set and the .net9 manifest in the 9 workload sets.