### PR TITLE
Add Aspire workload manifest for version <= 9

### DIFF
--- a/src/Microsoft.NET.Workloads/workloads.props
+++ b/src/Microsoft.NET.Workloads/workloads.props
@@ -25,4 +25,7 @@
     <WorkloadManifest Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(VersionMajor)', '10'))" Include="Microsoft.NET.Workload.Mono.ToolChain.net9"    FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
   </ItemGroup>
 
+  <ItemGroup Label="Aspire" Condition="$([MSBuild]::VersionLessThanOrEquals('$(VersionMajor)', '9'))">
+    <WorkloadManifest Include="Microsoft.NET.Sdk.Aspire" FeatureBand="$(AspireFeatureBand)" Version="$(AspireWorkloadManifestVersion)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Aspire was part of 8/9 workloads but the manifest was removed in our merge of eng.