### PR TITLE
Provide OfficialBuildId value

### DIFF
--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,7 +9,7 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    officialBuildId: $[variables['OfficialBuildId']]
+    officialBuildId: $[stageDependencies.Build.BuildRepo.outputs['SetRunName.OfficialBuildIdFromJob']]
     artifacts:
       publish:
         artifacts:
@@ -35,6 +35,7 @@ jobs:
       # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
       - powershell: |
           Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
+          Write-Host "##vso[task.setvariable variable=OfficialBuildIdFromJob;isoutput=true]$(Build.BuildNumber)"
           # Keep only valid characters. Invalid characters include: " / : < > \ | ? @ *
           # Also, strip any trailing '.' characters as those are invalid too.
           $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '["\/:<>\\|?@*]|\.{1,}$', ''
@@ -42,6 +43,8 @@ jobs:
           $commitMessage = $commitMessage.Substring(0, [Math]::Min($commitMessage.Length, 241))
           Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
         displayName: 🟣 Set run name via source branch commit message
+        # Name is required to reference the variables created within this build step in other stages.
+        name: SetRunName
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         # The convertToJson expression in AzDO creates "pretty" JSON with line breaks and indentation.
         # To simplify passing this JSON to scripts, we collapse it to a single line.

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,6 +9,7 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
+    officialBuildId: $(Build.BuildNumber)
     artifacts:
       publish:
         artifacts:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,7 +9,9 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    officialBuildId: $[stageDependencies.Build.BuildRepo.outputs['SetRunName.OfficialBuildIdFromJob']]
+    # This variable is evaluated when this job template is executed.
+    # Therefore, the value will not be affected by the updatebuildnumber script below.
+    officialBuildId: $[variables['Build.BuildNumber']]
     artifacts:
       publish:
         artifacts:
@@ -35,7 +37,6 @@ jobs:
       # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
       - powershell: |
           Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
-          Write-Host "##vso[task.setvariable variable=OfficialBuildIdFromJob;isoutput=true]$(Build.BuildNumber)"
           # Keep only valid characters. Invalid characters include: " / : < > \ | ? @ *
           # Also, strip any trailing '.' characters as those are invalid too.
           $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '["\/:<>\\|?@*]|\.{1,}$', ''
@@ -43,8 +44,6 @@ jobs:
           $commitMessage = $commitMessage.Substring(0, [Math]::Min($commitMessage.Length, 241))
           Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
         displayName: 🟣 Set run name via source branch commit message
-        # Name is required to reference the variables created within this build step in other stages.
-        name: SetRunName
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         # The convertToJson expression in AzDO creates "pretty" JSON with line breaks and indentation.
         # To simplify passing this JSON to scripts, we collapse it to a single line.

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,7 +9,7 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    officialBuildId: $[variables.Build.BuildNumber]
+    officialBuildId: $[variables['Build.BuildNumber']]
     artifacts:
       publish:
         artifacts:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,7 +9,7 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    officialBuildId: $[variables['Build.BuildNumber']]
+    officialBuildId: $[variables['OfficialBuildId']]
     artifacts:
       publish:
         artifacts:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,7 +9,7 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    officialBuildId: $(Build.BuildNumber)
+    officialBuildId: $(Date:yyyyMMdd).$(Rev:r)
     artifacts:
       publish:
         artifacts:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,7 +9,7 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    officialBuildId: $(OfficialBuildId)
+    officialBuildId: $[variables.OfficialBuildId]
     artifacts:
       publish:
         artifacts:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,7 +9,7 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    officialBuildId: $[variables.OfficialBuildId]
+    officialBuildId: $[variables.Build.BuildNumber]
     artifacts:
       publish:
         artifacts:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,7 +9,7 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    officialBuildId: $(Date:yyyyMMdd).$(Rev:r)
+    officialBuildId: $(OfficialBuildId)
     artifacts:
       publish:
         artifacts:


### PR DESCRIPTION
## Summary

When merging [this PR](https://github.com/dotnet/workload-versions/pull/529), I completely disregarded that I needed to still **send** the `OfficialBuildId` value once the Arcade changes were merged. This PR does that by sending it as an runtime expression. The value of the variable is evaluated when the [job template is executed](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops#what-is-the-difference-between-parameters-and-variables). This means it will contain the original `Build.BuildNumber` value and not the one we modify to change the build run name.