### PR TITLE
Comment out build number update but also include fix

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -6,7 +6,9 @@ pr: none
 
 # Required to set a custom run name within workload-build.yml.
 # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pipeline
-appendCommitMessageToRunName: false
+# ==========================
+# TODO: Temporarily commenting out updating the build number.
+# appendCommitMessageToRunName: false
 
 parameters:
 - name: sourceBranch

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,9 +9,9 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    # This variable is evaluated when this job template is executed.
-    # Therefore, the value will not be affected by the updatebuildnumber script below.
-    officialBuildId: $[variables['Build.BuildNumber']]
+    # # This variable is evaluated when this job template is executed.
+    # # Therefore, the value will not be affected by the updatebuildnumber script below.
+    # officialBuildId: $[variables['Build.BuildNumber']]
     artifacts:
       publish:
         artifacts:
@@ -32,18 +32,18 @@ jobs:
         parameters:
           sourceBranchAlias: source
           engBranchAlias: self
-      # Sets the run name to use the source branch commit message.
-      # Also, sets the OfficialBuildId variable to the original Build.BuildNumber for use in Arcade.
-      # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
-      - powershell: |
-          Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
-          # Keep only valid characters. Invalid characters include: " / : < > \ | ? @ *
-          # Also, strip any trailing '.' characters as those are invalid too.
-          $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '["\/:<>\\|?@*]|\.{1,}$', ''
-          # Lastly, truncate to 255 max characters: 241 = 255 - 14 (for build number and delimiter, ex: 20250910.13 • )
-          $commitMessage = $commitMessage.Substring(0, [Math]::Min($commitMessage.Length, 241))
-          Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
-        displayName: 🟣 Set run name via source branch commit message
+      # # Sets the run name to use the source branch commit message.
+      # # Also, sets the OfficialBuildId variable to the original Build.BuildNumber for use in Arcade.
+      # # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
+      # - powershell: |
+      #     Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
+      #     # Keep only valid characters. Invalid characters include: " / : < > \ | ? @ *
+      #     # Also, strip any trailing '.' characters as those are invalid too.
+      #     $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '["\/:<>\\|?@*]|\.{1,}$', ''
+      #     # Lastly, truncate to 255 max characters: 241 = 255 - 14 (for build number and delimiter, ex: 20250910.13 • )
+      #     $commitMessage = $commitMessage.Substring(0, [Math]::Min($commitMessage.Length, 241))
+      #     Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
+      #   displayName: 🟣 Set run name via source branch commit message
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         # The convertToJson expression in AzDO creates "pretty" JSON with line breaks and indentation.
         # To simplify passing this JSON to scripts, we collapse it to a single line.
@@ -79,7 +79,7 @@ jobs:
           /p:DotNetSignType=$(_SignType)
           /p:TeamName=$(_TeamName)
           /p:DotNetPublishUsingPipelines=true
-          /p:OfficialBuildId=$(OfficialBuildId)
+          /p:OfficialBuildId=$(Build.BuildNumber)
           /p:StabilizePackageVersion=${{ parameters.stabilizePackageVersion }}
         displayName: 🟣 Build solution
         # Name is required to reference the variables created within this build step in other stages.

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -43,7 +43,9 @@ jobs:
           $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '["\/:<>\\|?@*]|\.{1,}$', ''
           # Lastly, truncate to 255 max characters: 241 = 255 - 14 (for build number and delimiter, ex: 20250910.13 • )
           $commitMessage = $commitMessage.Substring(0, [Math]::Min($commitMessage.Length, 241))
-          Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
+          # ==========================
+          # TODO: Temporarily commenting out updating the build number.
+          # Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
         displayName: 🟣 Set run name via source branch commit message
         # Name is required to reference the variables created within this build step in other stages.
         name: SetRunName

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -9,9 +9,9 @@ jobs:
     publishAssetsImmediately: true
     enableSbom: true
     repositoryAlias: source
-    # # This variable is evaluated when this job template is executed.
-    # # Therefore, the value will not be affected by the updatebuildnumber script below.
-    # officialBuildId: $[variables['Build.BuildNumber']]
+    # This variable is evaluated when this job template is executed.
+    # Therefore, the value will not be affected by the updatebuildnumber script below.
+    officialBuildId: $[variables['Build.BuildNumber']]
     artifacts:
       publish:
         artifacts:
@@ -32,18 +32,21 @@ jobs:
         parameters:
           sourceBranchAlias: source
           engBranchAlias: self
-      # # Sets the run name to use the source branch commit message.
-      # # Also, sets the OfficialBuildId variable to the original Build.BuildNumber for use in Arcade.
-      # # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
-      # - powershell: |
-      #     Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
-      #     # Keep only valid characters. Invalid characters include: " / : < > \ | ? @ *
-      #     # Also, strip any trailing '.' characters as those are invalid too.
-      #     $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '["\/:<>\\|?@*]|\.{1,}$', ''
-      #     # Lastly, truncate to 255 max characters: 241 = 255 - 14 (for build number and delimiter, ex: 20250910.13 • )
-      #     $commitMessage = $commitMessage.Substring(0, [Math]::Min($commitMessage.Length, 241))
-      #     Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
-      #   displayName: 🟣 Set run name via source branch commit message
+      # Sets the run name to use the source branch commit message.
+      # Also, sets the OfficialBuildId variable to the original Build.BuildNumber for use in Arcade.
+      # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number
+      - powershell: |
+          Write-Host "##vso[task.setvariable variable=OfficialBuildId]$(Build.BuildNumber)"
+          Write-Host "##vso[task.setvariable variable=OfficialBuildIdFromJob;isoutput=true]$(Build.BuildNumber)"
+          # Keep only valid characters. Invalid characters include: " / : < > \ | ? @ *
+          # Also, strip any trailing '.' characters as those are invalid too.
+          $commitMessage = "$(git log -1 --pretty=%s)".Trim() -replace '["\/:<>\\|?@*]|\.{1,}$', ''
+          # Lastly, truncate to 255 max characters: 241 = 255 - 14 (for build number and delimiter, ex: 20250910.13 • )
+          $commitMessage = $commitMessage.Substring(0, [Math]::Min($commitMessage.Length, 241))
+          Write-Host "##vso[build.updatebuildnumber]$(Build.BuildNumber) • $commitMessage"
+        displayName: 🟣 Set run name via source branch commit message
+        # Name is required to reference the variables created within this build step in other stages.
+        name: SetRunName
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         # The convertToJson expression in AzDO creates "pretty" JSON with line breaks and indentation.
         # To simplify passing this JSON to scripts, we collapse it to a single line.
@@ -79,7 +82,7 @@ jobs:
           /p:DotNetSignType=$(_SignType)
           /p:TeamName=$(_TeamName)
           /p:DotNetPublishUsingPipelines=true
-          /p:OfficialBuildId=$(Build.BuildNumber)
+          /p:OfficialBuildId=$(OfficialBuildId)
           /p:StabilizePackageVersion=${{ parameters.stabilizePackageVersion }}
         displayName: 🟣 Build solution
         # Name is required to reference the variables created within this build step in other stages.

--- a/eng/pipelines/templates/jobs/workload-insertion-job.yml
+++ b/eng/pipelines/templates/jobs/workload-insertion-job.yml
@@ -19,6 +19,8 @@ jobs:
   templateContext:
     type: buildJob
   variables:
+  - name: OfficialBuildIdFromJob
+    value: $[stageDependencies.Build.BuildRepo.outputs['SetRunName.OfficialBuildIdFromJob']]
   - name: PrimaryVSComponentJsonValues
     value: $[stageDependencies.Build.BuildRepo.outputs['BuildSolution.PrimaryVSComponentJsonValues']]
   - name: SecondaryVSComponentJsonValues
@@ -90,6 +92,7 @@ jobs:
         topicBranch: ${{ parameters.vsTopicBranch }}
         # PrimaryVSComponentJsonValues variable is set during create-workload-drops.ps1 in Microsoft.NET.Workloads.Vsman.csproj.
         componentJsonValues: $(PrimaryVSComponentJsonValues)
+        officialBuildId: $(OfficialBuildIdFromJob)
   - ${{ each secondaryInsertionBranch in parameters.secondaryVsInsertionBranches }}:
     # One PR is created per branch defined at the top of official.yml in the secondaryVsInsertionBranches parameter.
     - template: /eng/pipelines/templates/steps/workload-insertion-steps.yml@self
@@ -98,3 +101,4 @@ jobs:
         topicBranch: ${{ parameters.vsTopicBranch }}
         # SecondaryVSComponentJsonValues variable is set during create-workload-drops.ps1 in Microsoft.NET.Workloads.Vsman.csproj.
         componentJsonValues: $(SecondaryVSComponentJsonValues)
+        officialBuildId: $(OfficialBuildIdFromJob)

--- a/eng/pipelines/templates/steps/workload-insertion-steps.yml
+++ b/eng/pipelines/templates/steps/workload-insertion-steps.yml
@@ -2,6 +2,7 @@ parameters:
   targetBranch: main
   topicBranch: ''
   componentJsonValues: ''
+  officialBuildId: ''
 
 steps:
 # This allows setting the InsertionTopicBranch variable dynamically.
@@ -16,7 +17,7 @@ steps:
     # Loosely based on:
     # https://devdiv.visualstudio.com/Engineering/_git/MicroBuild?path=/src/Tasks/InsertVsPayload/plugin.ps1&version=GCf10314b240d5f3d0899e80eb2feb5dc33b5f8c20&line=276&lineEnd=280&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
     if ($topicBranch -eq '|temp|') {
-      $topicBranch = 'temp/$(_TeamName)/${{ parameters.targetBranch }}/$(Build.BuildNumber)-$(System.JobAttempt)'
+      $topicBranch = 'temp/$(_TeamName)/${{ parameters.targetBranch }}/${{ parameters.officialBuildId }}-$(System.JobAttempt)'
     }
     Write-Host "InsertionTopicBranch: $topicBranch"
     Write-Host "##vso[task.setvariable variable=InsertionTopicBranch]$topicBranch"
@@ -34,7 +35,7 @@ steps:
     InsertionTopicBranch: $(InsertionTopicBranch)
     TeamName: $(_TeamName)
     TeamEmail: dotnetdevexcli@microsoft.com
-    InsertionPayloadName: 'DotNet-SDK-Workloads ($(Build.SourceBranchName):$(Build.BuildNumber))'
+    InsertionPayloadName: 'DotNet-SDK-Workloads ($(Build.SourceBranchName):${{ parameters.officialBuildId }})'
     ComponentJsonValues: ${{ parameters.componentJsonValues }}
     AllowTopicBranchUpdate: true
     # This is the name of our DevDiv alias.


### PR DESCRIPTION
## Summary

More issues with the build number update. This PR:

- Adds the logic to pass the original build number to the Insertion job
- Comments out actually updating the build number (temporarily) to allow builds without the Arcade changes to complete