### PR TITLE
Allow version parameters for official builds

### DIFF
--- a/eng/create-version-override.ps1
+++ b/eng/create-version-override.ps1
@@ -1,54 +1,108 @@
-# Using the downloaded workloads, this creates the VS drops to upload for VS insertion.
-# It builds the Microsoft.NET.Workloads.Vsman.vsmanproj per workload ZIP, which creates the appropriate VSMAN file.
+# Creates a Version.Overrides.props file to override version components for the workload set creation.
 
-# $workloadPath: The path to the directory containing the workload ZIPs, usually the output path used by DARC in the download-workloads.ps1 script.
-# - Example Value: "$(RepoRoot)artifacts\workloads"
-# $msBuildToolsPath: The path to the MSBuild tools directory, generally $(MSBuildToolsPath) in MSBuild.
-# - Example Value: 'C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin'
+# $createTestWorkloadSet:
+# - If $true, adds PreReleaseVersionIteration overrides for creating a test workload set.
+# - If $false, does not add any PreReleaseVersionIteration overrides.
+# $versionSdkMinor: Adds the VersionSdkMinor property to the Version.Overrides.props file with the provided value.
+# - Example Value: '2'
+# $versionFeature: Adds the VersionFeature property to the Version.Overrides.props file with the provided value.
+# - Example Value: '01'
+# $versionPatch: Adds the VersionPatch property to the Version.Overrides.props file with the provided value.
+# - Example Value: '4'
+# $preReleaseVersionLabel: Adds the PreReleaseVersionLabel property to the Version.Overrides.props file with the provided value.
+# - Example Value: 'preview'
+# $preReleaseVersionIteration: Adds the PreReleaseVersionIteration property to the Version.Overrides.props file with the provided value.
+# - Example Value: '1'
 
-param ([bool] $createTestWorkloadSet = $false, [string] $sdkVersionMinor = '|default|', [string] $versionFeature = '|default|', [string] $versionPatch = '|default|', [string] $preReleaseVersionLabel = '|default|', [string] $preReleaseVersionIteration = '|default|')
+param ([bool] $createTestWorkloadSet = $false, [string] $versionSdkMinor = '|default|', [string] $versionFeature = '|default|', [string] $versionPatch = '|default|', [string] $preReleaseVersionLabel = '|default|', [string] $preReleaseVersionIteration = '|default|')
 
 $containsNonDefault = ($sdkVersionMinor, $versionFeature, $versionPatch, $preReleaseVersionLabel, $preReleaseVersionIteration | Where-Object { $_ -ne '|default|' }) -ne $null
 
 if (-not $containsNonDefault -and -not $createTestWorkloadSet) {
-    Write-Host "No version overrides to apply."
-    exit 0
+  Write-Host 'No version overrides to apply.'
+  exit 0
 }
 
 $xmlDoc = New-Object System.Xml.XmlDocument
-$projectElement = $xmlDoc.CreateElement("Project")
-$xmlDoc.AppendChild($rootElement)
+$project = $xmlDoc.CreateElement('Project')
+$propertyGroup1 = $xmlDoc.CreateElement('PropertyGroup')
 
-$propertyGroup1Element = $xmlDoc.CreateElement("PropertyGroup")
-$projectElement.AppendChild($propertyGroup1Element)
+if ($versionSdkMinor -ne '|default|') {
+  $versionSdkMinorElem = $xmlDoc.CreateElement('VersionSdkMinor')
+  $versionSdkMinorElem.InnerText = $versionSdkMinor
+  $null = $propertyGroup1.AppendChild($versionSdkMinorElem)
+  Write-Host "Setting VersionSdkMinor to $versionSdkMinor."
+}
 
-$propertyGroup2Element = $xmlDoc.CreateElement("PropertyGroup")
-$projectElement.AppendChild($propertyGroup2Element)
+if ($versionFeature -ne '|default|') {
+  $versionFeatureElem = $xmlDoc.CreateElement('VersionFeature')
+  $versionFeatureElem.InnerText = $versionFeature
+  $null = $propertyGroup1.AppendChild($versionFeatureElem)
+  Write-Host "Setting VersionFeature to $versionFeature."
+}
 
+if ($versionPatch -ne '|default|') {
+  $versionPatchElem = $xmlDoc.CreateElement('VersionPatch')
+  $versionPatchElem.InnerText = $versionPatch
+  $null = $propertyGroup1.AppendChild($versionPatchElem)
+  Write-Host "Setting VersionPatch to $versionPatch."
+}
 
-$settingElement.SetAttribute("Name", "LogLevel")
-$settingElement.InnerText = "Debug"
+if ($preReleaseVersionLabel -ne '|default|') {
+  $preReleaseVersionLabelElem = $xmlDoc.CreateElement('PreReleaseVersionLabel')
+  $preReleaseVersionLabelElem.InnerText = $preReleaseVersionLabel
+  $null = $propertyGroup1.AppendChild($preReleaseVersionLabelElem)
+  Write-Host "Setting PreReleaseVersionLabel to $preReleaseVersionLabel."
+}
 
-$xmlDoc.Save("D:\Workspace\TestMe.xml")
+if ($preReleaseVersionIteration -ne '|default|') {
+  $preReleaseVersionIterationElem = $xmlDoc.CreateElement('PreReleaseVersionIteration')
+  $null = $preReleaseVersionIterationElem.SetAttribute('Condition', "'`$(StabilizePackageVersion)' != 'true'")
+  $preReleaseVersionIterationElem.InnerText = $preReleaseVersionIteration
+  $null = $propertyGroup1.AppendChild($preReleaseVersionIterationElem)
+  Write-Host "Setting PreReleaseVersionIteration to $preReleaseVersionIteration."
+}
 
+$null = $project.AppendChild($propertyGroup1)
+$propertyGroup2 = $xmlDoc.CreateElement('PropertyGroup')
 
+$versionPrefix = $xmlDoc.CreateElement('VersionPrefix')
+$versionPrefix.InnerText = '$(VersionMajor).$(VersionSdkMinor)$(VersionFeature).$(VersionPatch)'
+$null = $propertyGroup2.AppendChild($versionPrefix)
 
-# <Project>
-#   <PropertyGroup>
-#     <VersionSDKMinor>3</VersionSDKMinor>
-#     <VersionFeature>05</VersionFeature>
-#     <VersionPatch>0</VersionPatch>
-#     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-#     <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'">1</PreReleaseVersionIteration>
-#   </PropertyGroup>
-#   <PropertyGroup>
-#     <VersionPrefix>$(VersionMajor).$(VersionSDKMinor)$(VersionFeature).$(VersionPatch)</VersionPrefix>
-#     <WorkloadsVersion>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</WorkloadsVersion>
-#     <WorkloadsVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(VersionPatch)' != '0'">$(WorkloadsVersion).$(VersionPatch)</WorkloadsVersion>
-#     <SdkFeatureBand>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)00</SdkFeatureBand>
-#     <SdkFeatureBand Condition="'$(StabilizePackageVersion)' != 'true' and $(PreReleaseVersionLabel) != 'servicing'">$(SdkFeatureBand)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</SdkFeatureBand>
-#     <!-- Conditional include -->
-#     <PreReleaseVersionIteration Condition="'$(TestWorkloadVersion)' == 'true' and $(PreReleaseVersionLabel) != 'servicing'">$(PreReleaseVersionIteration).0</PreReleaseVersionIteration>
-#     <PreReleaseVersionIteration Condition="'$(TestWorkloadVersion)' == 'true' and $(PreReleaseVersionLabel) == 'servicing'">0</PreReleaseVersionIteration>
-#   </PropertyGroup>
-# </Project>
+$workloadsVersion1 = $xmlDoc.CreateElement('WorkloadsVersion')
+$workloadsVersion1.InnerText = '$(VersionMajor).$(VersionMinor).$(VersionSdkMinor)$(VersionFeature)'
+$null = $propertyGroup2.AppendChild($workloadsVersion1)
+
+$workloadsVersion2 = $xmlDoc.CreateElement('WorkloadsVersion')
+$null = $workloadsVersion2.SetAttribute('Condition', "'`$(StabilizePackageVersion)' == 'true' and '`$(VersionPatch)' != '0'")
+$workloadsVersion2.InnerText = '$(WorkloadsVersion).$(VersionPatch)'
+$null = $propertyGroup2.AppendChild($workloadsVersion2)
+
+$sdkFeatureBand1 = $xmlDoc.CreateElement('SdkFeatureBand')
+$sdkFeatureBand1.InnerText = '$(VersionMajor).$(VersionMinor).$(VersionSdkMinor)00'
+$null = $propertyGroup2.AppendChild($sdkFeatureBand1)
+
+$sdkFeatureBand2 = $xmlDoc.CreateElement('SdkFeatureBand')
+$null = $sdkFeatureBand2.SetAttribute('Condition', "'`$(StabilizePackageVersion)' != 'true' and '`$(PreReleaseVersionLabel)' != 'servicing'")
+$sdkFeatureBand2.InnerText = '$(SdkFeatureBand)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)'
+$null = $propertyGroup2.AppendChild($sdkFeatureBand2)
+
+if ($createTestWorkloadSet) {
+  $preReleaseVersionIteration1 = $xmlDoc.CreateElement('PreReleaseVersionIteration')
+  $null = $preReleaseVersionIteration1.SetAttribute('Condition', "'`$(PreReleaseVersionLabel)' != 'servicing'")
+  $preReleaseVersionIteration1.InnerText = '$(PreReleaseVersionIteration).0'
+  $null = $propertyGroup2.AppendChild($preReleaseVersionIteration1)
+
+  $preReleaseVersionIteration2 = $xmlDoc.CreateElement('PreReleaseVersionIteration')
+  $null = $preReleaseVersionIteration2.SetAttribute('Condition', "'`$(PreReleaseVersionLabel)' == 'servicing'")
+  $preReleaseVersionIteration2.InnerText = '0'
+  $null = $propertyGroup2.AppendChild($preReleaseVersionIteration2)
+  Write-Host 'Setting PreReleaseVersionIteration for test workload set.'
+}
+
+$null = $project.AppendChild($propertyGroup2)
+$null = $xmlDoc.AppendChild($project)
+
+$versionOverridesPath = Join-Path -Path $PSScriptRoot -ChildPath 'Version.Overrides.props'
+$null = $xmlDoc.Save($versionOverridesPath)

--- a/eng/create-version-override.ps1
+++ b/eng/create-version-override.ps1
@@ -1,0 +1,54 @@
+# Using the downloaded workloads, this creates the VS drops to upload for VS insertion.
+# It builds the Microsoft.NET.Workloads.Vsman.vsmanproj per workload ZIP, which creates the appropriate VSMAN file.
+
+# $workloadPath: The path to the directory containing the workload ZIPs, usually the output path used by DARC in the download-workloads.ps1 script.
+# - Example Value: "$(RepoRoot)artifacts\workloads"
+# $msBuildToolsPath: The path to the MSBuild tools directory, generally $(MSBuildToolsPath) in MSBuild.
+# - Example Value: 'C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin'
+
+param ([bool] $createTestWorkloadSet = $false, [string] $sdkVersionMinor = '|default|', [string] $versionFeature = '|default|', [string] $versionPatch = '|default|', [string] $preReleaseVersionLabel = '|default|', [string] $preReleaseVersionIteration = '|default|')
+
+$containsNonDefault = ($sdkVersionMinor, $versionFeature, $versionPatch, $preReleaseVersionLabel, $preReleaseVersionIteration | Where-Object { $_ -ne '|default|' }) -ne $null
+
+if (-not $containsNonDefault -and -not $createTestWorkloadSet) {
+    Write-Host "No version overrides to apply."
+    exit 0
+}
+
+$xmlDoc = New-Object System.Xml.XmlDocument
+$projectElement = $xmlDoc.CreateElement("Project")
+$xmlDoc.AppendChild($rootElement)
+
+$propertyGroup1Element = $xmlDoc.CreateElement("PropertyGroup")
+$projectElement.AppendChild($propertyGroup1Element)
+
+$propertyGroup2Element = $xmlDoc.CreateElement("PropertyGroup")
+$projectElement.AppendChild($propertyGroup2Element)
+
+
+$settingElement.SetAttribute("Name", "LogLevel")
+$settingElement.InnerText = "Debug"
+
+$xmlDoc.Save("D:\Workspace\TestMe.xml")
+
+
+
+# <Project>
+#   <PropertyGroup>
+#     <VersionSDKMinor>3</VersionSDKMinor>
+#     <VersionFeature>05</VersionFeature>
+#     <VersionPatch>0</VersionPatch>
+#     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
+#     <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'">1</PreReleaseVersionIteration>
+#   </PropertyGroup>
+#   <PropertyGroup>
+#     <VersionPrefix>$(VersionMajor).$(VersionSDKMinor)$(VersionFeature).$(VersionPatch)</VersionPrefix>
+#     <WorkloadsVersion>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</WorkloadsVersion>
+#     <WorkloadsVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(VersionPatch)' != '0'">$(WorkloadsVersion).$(VersionPatch)</WorkloadsVersion>
+#     <SdkFeatureBand>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)00</SdkFeatureBand>
+#     <SdkFeatureBand Condition="'$(StabilizePackageVersion)' != 'true' and $(PreReleaseVersionLabel) != 'servicing'">$(SdkFeatureBand)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</SdkFeatureBand>
+#     <!-- Conditional include -->
+#     <PreReleaseVersionIteration Condition="'$(TestWorkloadVersion)' == 'true' and $(PreReleaseVersionLabel) != 'servicing'">$(PreReleaseVersionIteration).0</PreReleaseVersionIteration>
+#     <PreReleaseVersionIteration Condition="'$(TestWorkloadVersion)' == 'true' and $(PreReleaseVersionLabel) == 'servicing'">0</PreReleaseVersionIteration>
+#   </PropertyGroup>
+# </Project>

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -85,12 +85,16 @@ parameters:
   displayName: '[ ######## SET VERSION ######## ]'
   type: boolean
   default: false
-- name: setVersionMajor
-  displayName: Set version major
-  type: string
-  default: '|default|'
-- name: setVersionMinor
-  displayName: Set version minor (one digit)
+# - name: setVersionMajor
+#   displayName: Set version major
+#   type: string
+#   default: '|default|'
+# - name: setVersionMinor
+#   displayName: Set version minor
+#   type: string
+#   default: '|default|'
+- name: setSdkVersionMinor
+  displayName: Set SDK version minor (one digit)
   type: string
   default: '|default|'
 - name: setVersionFeature
@@ -101,6 +105,25 @@ parameters:
   displayName: Set version patch
   type: string
   default: '|default|'
+- name: setPreReleaseVersionLabel
+  displayName: Set pre-release version label
+  type: string
+  default: '|default|'
+  values:
+  - '|default|'
+  - servicing
+  - preview
+  - rc
+  - alpha
+  - rtm
+- name: setPreReleaseVersionIteration
+  displayName: Set pre-release version iteration
+  type: string
+  default: '|default|'
+- name: createTestWorkloadSet
+  displayName: Create a test workload set
+  type: boolean
+  default: false
 
 variables:
 # Variables used: DncEngInternalBuildPool

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -93,8 +93,8 @@ parameters:
 #   displayName: Set version minor
 #   type: string
 #   default: '|default|'
-- name: setSdkVersionMinor
-  displayName: Set SDK version minor (one digit)
+- name: setVersionSdkMinor
+  displayName: Set version SDK minor (one digit)
   type: string
   default: '|default|'
 - name: setVersionFeature

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -81,6 +81,27 @@ parameters:
   type: boolean
   default: false
 
+- name: dividerSetVersion
+  displayName: '[ ######## SET VERSION ######## ]'
+  type: boolean
+  default: false
+- name: setVersionMajor
+  displayName: Set version major
+  type: string
+  default: '|default|'
+- name: setVersionMinor
+  displayName: Set version minor (one digit)
+  type: string
+  default: '|default|'
+- name: setVersionFeature
+  displayName: Set version feature (two digits)
+  type: string
+  default: '|default|'
+- name: setVersionPatch
+  displayName: Set version patch
+  type: string
+  default: '|default|'
+
 variables:
 # Variables used: DncEngInternalBuildPool
 - template: /eng/common/templates-official/variables/pool-providers.yml@source

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -85,14 +85,6 @@ parameters:
   displayName: '[ ######## SET VERSION ######## ]'
   type: boolean
   default: false
-# - name: setVersionMajor
-#   displayName: Set version major
-#   type: string
-#   default: '|default|'
-# - name: setVersionMinor
-#   displayName: Set version minor
-#   type: string
-#   default: '|default|'
 - name: setVersionSdkMinor
   displayName: Set version SDK minor (one digit)
   type: string
@@ -193,6 +185,12 @@ extends:
           usePreComponentsForVSInsertion: ${{ parameters.usePreComponentsForVSInsertion }}
           includeNonShippingWorkloads: ${{ parameters.includeNonShippingWorkloads }}
           workloadDropNames: ${{ parameters.workloadDropNames }}
+          createTestWorkloadSet: ${{ parameters.createTestWorkloadSet }}
+          setVersionSdkMinor: ${{ parameters.setVersionSdkMinor }}
+          setVersionFeature: ${{ parameters.setVersionFeature }}
+          setVersionPatch: ${{ parameters.setVersionPatch }}
+          setPreReleaseVersionLabel: ${{ parameters.setPreReleaseVersionLabel }}
+          setPreReleaseVersionIteration: ${{ parameters.setPreReleaseVersionIteration }}
 
     - ${{ if eq(parameters.createVSInsertion, true) }}:
       - stage: Insertion

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -116,6 +116,7 @@ parameters:
   - rc
   - alpha
   - rtm
+  - test
 - name: setPreReleaseVersionIteration
   displayName: Set pre-release version iteration
   type: string

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -12,6 +12,10 @@ parameters:
 - name: sourceBranch
   displayName: 🚩 Source branch 🚩
   type: string
+- name: createTestWorkloadSet
+  displayName: ⭐ Create a test workload set
+  type: boolean
+  default: false
 
 - name: dividerAzDO
   displayName: '[ ######## AZURE DEVOPS ######## ]'
@@ -116,10 +120,6 @@ parameters:
   displayName: Set pre-release version iteration
   type: string
   default: '|default|'
-- name: createTestWorkloadSet
-  displayName: Create a test workload set
-  type: boolean
-  default: false
 
 variables:
 # Variables used: DncEngInternalBuildPool

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -53,7 +53,14 @@ jobs:
               -workloadListJson '$(WorkloadListJson)'
               -usePreComponents:$${{ parameters.usePreComponentsForVSInsertion }}
               -includeNonShipping:$${{ parameters.includeNonShippingWorkloads }}
-      - powershell: 'Insert script here'
+      - powershell: eng/create-version-override.ps1
+          -createTestWorkloadSet:$${{ parameters.createTestWorkloadSet }}
+          -versionSdkMinor '${{ parameters.setVersionSdkMinor }}'
+          -versionFeature '${{ parameters.setVersionFeature }}'
+          -versionPatch '${{ parameters.setVersionPatch }}'
+          -preReleaseVersionLabel '${{ parameters.setPreReleaseVersionLabel }}'
+          -preReleaseVersionIteration '${{ parameters.setPreReleaseVersionIteration }}'
+        displayName: 🟣 Create Version.Overrides.props
       # https://github.com/dotnet/arcade/blob/ccae251ef033746eb0213329953f5e3c1687693b/Documentation/CorePackages/Publishing.md#basic-onboarding-scenario-for-new-repositories-to-the-current-publishing-version-v3
       - powershell: >-
           eng/common/build.ps1

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -53,7 +53,7 @@ jobs:
               -workloadListJson '$(WorkloadListJson)'
               -usePreComponents:$${{ parameters.usePreComponentsForVSInsertion }}
               -includeNonShipping:$${{ parameters.includeNonShippingWorkloads }}
-
+      - powershell: 'Insert script here'
       # https://github.com/dotnet/arcade/blob/ccae251ef033746eb0213329953f5e3c1687693b/Documentation/CorePackages/Publishing.md#basic-onboarding-scenario-for-new-repositories-to-the-current-publishing-version-v3
       - powershell: >-
           eng/common/build.ps1
@@ -69,7 +69,6 @@ jobs:
         displayName: 🟣 Build solution
         # Name is required to reference the variables created within this build step in other stages.
         name: BuildSolution
-
       - ${{ if eq(parameters.createVSInsertion, true) }}:
         - task: 1ES.PublishPipelineArtifact@1
           displayName: 🟣 Publish workload artifacts


### PR DESCRIPTION
## Summary

The purpose is to enable the ability to override the version number values within `Versions.props` with values provided at queue-time when doing official builds. To do this, I've already merged a change to the normal branches (release/8.0.4xx, release/9.0.1xx, main) that allows loading a `Version.Overrides.props` if it exists at the end of their `Versions.props` file. That way, any properties defined in `Versions.props` can be overridden prior to use.

> [!NOTE]  
> `|default|` is used as a sentinel value to indicate that the value should not be overridden from what is already defined in `Versions.props`.

The easiest way was to make a simple script that takes in the values from the pipeline via pipeline parameters and send them to the script. I've minimized the number of parameters to include only the ones we'd be likely to change. For example, the major version is not included since each branch is essentially defined by its major version. So, changing this would be unlikely.

This script simply does some XML creation to make the `Version.Overrides.props`. Additionally, this adds a `createTestWorkloadSet` flag that will add an additional `.0` to the end of the `PreReleaseVersionIteration`. This is for partner teams to make test workload sets that shouldn't be loaded without explicit version selection.
