### PR TITLE
Update network isolation policy

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -163,9 +163,9 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     settings:
-      # Default is 'Preferred,CFSClean' which blocks NuGet.org for publishing.
+      # Default is 'Permissive,CFSClean' which blocks NuGet.org for publishing.
       # Docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-build/cloudbuild/security/1espt-network-isolation
-      networkIsolationPolicy: Preferred
+      networkIsolationPolicy: Permissive
     sdl:
       # Docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/sourceanalysisstage#my-pipeline-uses-multiple-repositories-how-to-ensure-that-sdl-sources-stage-is-injected-for-all-the-repositories
       sourceRepositoriesToScan:


### PR DESCRIPTION
## Summary

It seems that the network isolation policy in DNCEng changed from `Permissive` to `Permissive,CFSClean`. That second policy, `CFSClean`, blocks our ability to publish to NuGet.org. This PR sets the policy back to `Permissive` only.

Docs on network isolation policy: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-build/cloudbuild/security/1espt-network-isolation