### PR TITLE
Migrate dn-bot-devdiv-drop-rw-code-rw PAT to WIF service connection

### DIFF
--- a/eng/pipelines/templates/jobs/workload-insertion-job.yml
+++ b/eng/pipelines/templates/jobs/workload-insertion-job.yml
@@ -45,6 +45,15 @@ jobs:
     inputs:
       artifactName: Workloads
       targetPath: $(System.DefaultWorkingDirectory)/artifacts/workloads
+  - task: AzureCLI@2
+    displayName: 🟣 Get DevDiv Drop Access Token
+    inputs:
+      azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+        Write-Host "##vso[task.setvariable variable=DevDivDropAccessToken;issecret=true]$token"
   # The variables comprised of workloadShortName and workloadType are set during create-workload-drops.ps1 in Microsoft.NET.Workloads.Vsman.csproj.
   - ${{ each workloadShortName in parameters.workloadDropNames }}:
     - ${{ each workloadType in parameters.workloadDropTypes }}:
@@ -80,7 +89,7 @@ jobs:
           dropName: $(${{ workloadShortName }}_${{ workloadType }}_name)
           # See: https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/35351/Retain-Drops
           dropRetentionDays: 183
-          accessToken: $(dn-bot-devdiv-drop-rw-code-rw)
+          accessToken: $(DevDivDropAccessToken)
           skipUploadIfExists: true
         condition: eq(variables['PublishWorkloadDrop'], 'True')
 


### PR DESCRIPTION
## Summary

Migrate the `dn-bot-devdiv-drop-rw-code-rw` PAT to Workload Identity Federation (WIF) for VSTS drop uploads in the VS insertion job.

## Changes

- Add `AzureCLI@2` step in `workload-insertion-job.yml` to obtain a DevDiv-scoped access token via the `dnceng-devdiv-drop-rw-code-rw-wif` service connection
- Replace `accessToken: $(dn-bot-devdiv-drop-rw-code-rw)` with the WIF-obtained `$(DevDivDropAccessToken)` variable
- The token is acquired once before the workload drop publish loop and reused for all iterations

## Validation

- The same WIF pattern has been validated in other repos:
  - **dotnet/fsharp** test build [2952255](https://dev.azure.com/dnceng/internal/_build/results?buildId=2952255) — token acquisition + drop upload succeeded
  - **dotnet/interactive-window** test build [2952263](https://dev.azure.com/dnceng/internal/_build/results?buildId=2952263) — token acquisition + drop upload succeeded
  - **dotnet/test-templates** test build [2952127](https://dev.azure.com/dnceng/internal/_build/results?buildId=2952127) — fully validated
- Direct test build for this pipeline was not feasible (trigger: none, requires content branch parameters that would create real VS insertions)

## Context

Part of PAT-to-Entra migration tracked by [AB#10146](https://dev.azure.com/dnceng/internal/_workitems/edit/10146).
