### PR TITLE
Allow publishing workload .nupkg files

### DIFF
--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -41,10 +41,10 @@ if (-not $workloadListJson) {
   $workloadListJson = '[]';
 }
 if (-not $workloadNupkgExcludeListJson) {
-   $workloadNupkgExcludeListJson = '[]';
+  $workloadNupkgExcludeListJson = '[]';
 }
 if (-not $workloadNupkgPath) {
-   $workloadNupkgPath = "$workloadPath/packages/workloadNupkgs";
+  $workloadNupkgPath = "$workloadPath/packages/workloadNupkgs";
 }
 
 $nonShippingFlag = ''

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -79,7 +79,8 @@ if ($ci) {
 # Reads the Version.Details.xml file to get the workload builds.
 $versionDetailsPath = (Get-Item "$PSScriptRoot/Version.Details.xml").FullName
 $versionDetailsXml = [Xml.XmlDocument](Get-Content $versionDetailsPath)
-$versionDetails = $versionDetailsXml.Dependencies.ProductDependencies.Dependency | Select-Object -Property Name, Version, Uri, Sha, BarId -Unique
+# DropName is not a value in the Version.Details.xml. We end up adding the drop name after the workload drop is downloaded.
+$versionDetails = $versionDetailsXml.Dependencies.ProductDependencies.Dependency | Select-Object -Property Name, Version, Uri, Sha, BarId, DropName -Unique
 
 # Construct the asset filter to only download the required workload drops.
 $workloadFilter = ''
@@ -103,6 +104,9 @@ Write-Host "assetFilter: $assetFilter"
 $versionDetails | ForEach-Object {
   Write-Host "Dependency name: $($_.Name)"
   Write-Host "Dependency version: $($_.Version)"
+
+  # Prior to running, we want to compare the contents of the output folder to see if the drop was acquired.
+  $workloadDropsBefore = Get-ChildItem $workloadPath -File -Recurse
 
   $darcArguments = @(
     'gather-drop'
@@ -135,6 +139,17 @@ $versionDetails | ForEach-Object {
   Write-Host "darcBuildArguments: $($darcBuildArguments | Join-String -Separator ' ')"
 
   & $darc ($darcArguments + $darcBuildArguments + $ciArguments)
+
+  # Check if a workload drop was downloaded.
+  $workloadDropsAfter = Get-ChildItem $workloadPath -File -Recurse
+  $workloadDrops = (Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter).InputObject
+  if ($workloadDrops) {
+    # Only use the first file to extract the drop name.
+    $dropToParse = $workloadDrops | Select-Object -First 1
+    $null = $dropToParse.Name -match 'Workload\.VSDrop\.([^.]+)\.'
+    # DropName is needed for the workload .nupkg download process below.
+    $_.DropName = $Matches[1]
+  }
 }
 
 Write-Host 'Workload drops downloaded:'
@@ -151,46 +166,41 @@ if ($downloadWorkloadNupkgs) {
   $nupkgAssetFilter = '(?<!\.symbols\.nupkg)(\.nupkg)$'
 
   $filteredWorkloadDropNames | ForEach-Object {
-    # Check if the workload drop path contains any files with this workload name in the filename.
     $dropName = $_
-    $workloadDrops = Get-ChildItem $workloadPath -File -Recurse | Where-Object { $_.Name -match $dropName }
-    if ($workloadDrops) {
-      Write-Host "Downloading .nupkgs for workload: $dropName"
+    $versionDetail = $versionDetails | Where-Object { $_.DropName -eq $dropName } | Select-Object -First 1
 
-      $workloadDrops | ForEach-Object {
-        $nupkgDarcArguments = @(
-          'gather-drop'
-          '--asset-filter'
-          $nupkgAssetFilter
-          '--output-dir'
-          $workloadNupkgPath
-          '--include-released'
-          '--skip-existing'
-          '--continue-on-error'
-          '--use-azure-credential-for-blobs'
-          $nonShippingFlag
-        )
+    Write-Host "Downloading .nupkgs for workload: $dropName"
+    $nupkgDarcArguments = @(
+      'gather-drop'
+      '--asset-filter'
+      $nupkgAssetFilter
+      '--output-dir'
+      $workloadNupkgPath
+      '--include-released'
+      '--skip-existing'
+      '--continue-on-error'
+      '--use-azure-credential-for-blobs'
+      $nonShippingFlag
+    )
 
-        $nupkgDarcBuildArguments = @(
-          '--repo'
-          $_.Uri
-          '--commit'
-          $_.Sha
-        )
+    $nupkgDarcBuildArguments = @(
+      '--repo'
+      $versionDetail.Uri
+      '--commit'
+      $versionDetail.Sha
+    )
 
-        if ($_.BarId) {
-          $nupkgDarcBuildArguments = @(
-            '--id'
-            $_.BarId
-          )
-        }
-
-        Write-Host "nupkgDarcArguments: $($nupkgDarcArguments | Join-String -Separator ' ')"
-        Write-Host "nupkgDarcBuildArguments: $($nupkgDarcBuildArguments | Join-String -Separator ' ')"
-
-        & $darc ($nupkgDarcArguments + $nupkgDarcBuildArguments + $ciArguments)
-      }
+    if ($versionDetail.BarId) {
+      $nupkgDarcBuildArguments = @(
+        '--id'
+        $versionDetail.BarId
+      )
     }
+
+    Write-Host "nupkgDarcArguments: $($nupkgDarcArguments | Join-String -Separator ' ')"
+    Write-Host "nupkgDarcBuildArguments: $($nupkgDarcBuildArguments | Join-String -Separator ' ')"
+
+    & $darc ($nupkgDarcArguments + $nupkgDarcBuildArguments + $ciArguments)
   }
 
   Write-Host 'Workload .nupkgs downloaded:'

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -178,7 +178,7 @@ if ($downloadWorkloadNupkgs) {
   $filteredWorkloadDropNames = ConvertFrom-Json -InputObject $workloadListJson | Where-Object { $nupkgExcludeList -notcontains $_ }
 
   # Asset filter for .nupkg files, excluding .symbols.nupkg.
-  $nupkgAssetFilter = '(?<!\.symbols)\.nupkg$'
+  $nupkgAssetFilter = '*(?<!\.symbols)\.nupkg$'
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -79,8 +79,8 @@ if ($ci) {
 # Reads the Version.Details.xml file to get the workload builds.
 $versionDetailsPath = (Get-Item "$PSScriptRoot/Version.Details.xml").FullName
 $versionDetailsXml = [Xml.XmlDocument](Get-Content $versionDetailsPath)
-# DropName is not a value in the Version.Details.xml. We end up adding the drop name after the workload drop is downloaded.
-$versionDetails = $versionDetailsXml.Dependencies.ProductDependencies.Dependency | Select-Object -Property Name, Version, Uri, Sha, BarId, DropName -Unique
+# DropNames is not a value in the Version.Details.xml. We end up adding the drop name(s) after downloading the drops.
+$versionDetails = $versionDetailsXml.Dependencies.ProductDependencies.Dependency | Select-Object -Property Name, Version, Uri, Sha, BarId, DropNames -Unique
 
 # Construct the asset filter to only download the required workload drops.
 $workloadFilter = ''
@@ -149,13 +149,12 @@ $versionDetails | ForEach-Object {
     $workloadDropsAfter = @()
   }
 
-  $workloadDrops = (Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter).InputObject
-  if ($workloadDrops) {
-    # Only use the first file to extract the drop name.
-    $dropToParse = $workloadDrops | Select-Object -First 1
-    $null = $dropToParse.Name -match 'Workload\.VSDrop\.([^.]+)\.'
-    # DropName is needed for the workload .nupkg download process below.
-    $_.DropName = $Matches[1]
+  $workloadDropFileNames = (Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter).InputObject.Name
+  if ($workloadDropFileNames) {
+    # Get the drop name(s) by extracting the name out of the downloaded files.
+    # DropNames are needed for the workload .nupkg download process below.
+    $_.DropNames = $workloadDropFileNames | ForEach-Object { if ($_ -match 'Workload\.VSDrop\.([^.]+)\.') { $Matches[1] } } | Select-Object -Unique
+    Write-Host "DropNames: $($_.DropNames -join ', ')"
   }
 }
 
@@ -174,7 +173,7 @@ if ($downloadWorkloadNupkgs) {
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_
-    $versionDetail = $versionDetails | Where-Object { $_.DropName -eq $dropName } | Select-Object -First 1
+    $versionDetail = $versionDetails | Where-Object { $_.DropNames -contains $dropName } | Select-Object -First 1
 
     Write-Host "Downloading .nupkgs for workload: $dropName"
     $nupkgDarcArguments = @(

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -91,7 +91,7 @@ if ($workloadList.Length -ne 0) {
   $workloadFilter = "($($workloadList | Join-String -Separator '|'))"
 }
 
-# Note: The $ at the end of these filters are required for the positive/negative lookbehinds to function.
+# Note: The $ at the end of these filters are required for the positive/negative lookbehinds to function in DARC.
 # Exclude pre.components.zip.
 $componentFilter = '(?<!pre\.components\.zip)$'
 if ($usePreComponents) {
@@ -150,7 +150,7 @@ $versionDetails | ForEach-Object {
     $workloadDropsAfter = @()
   }
 
-  $fileDelta = Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter
+  $fileDelta = Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter -Property FullName
   if ($fileDelta) {
     $workloadDropFileNames = $fileDelta.InputObject.Name
     # Get the drop name(s) by extracting the name out of the downloaded files.
@@ -171,7 +171,8 @@ if ($downloadWorkloadNupkgs) {
   $filteredWorkloadDropNames = ConvertFrom-Json -InputObject $workloadListJson | Where-Object { $nupkgExcludeList -notcontains $_ }
 
   # Asset filter for .nupkg files, excluding .symbols.nupkg.
-  $nupkgAssetFilter = '\.nupkg(?<!\.symbols\.nupkg)$'
+  # Note: The $ at the end of these filters are required for the positive/negative lookbehinds to function in DARC.
+  $nupkgAssetFilter = '^.*\.nupkg(?<!\.symbols\.nupkg)$'
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -107,6 +107,9 @@ $versionDetails | ForEach-Object {
 
   # Prior to running, we want to compare the contents of the output folder to see if the drop was acquired.
   $workloadDropsBefore = Get-ChildItem $workloadPath -File -Recurse
+  if (-not $workloadDropsBefore) {
+    $workloadDropsBefore = @()
+  }
 
   $darcArguments = @(
     'gather-drop'
@@ -142,6 +145,10 @@ $versionDetails | ForEach-Object {
 
   # Check if a workload drop was downloaded.
   $workloadDropsAfter = Get-ChildItem $workloadPath -File -Recurse
+  if (-not $workloadDropsAfter) {
+    $workloadDropsAfter = @()
+  }
+
   $workloadDrops = (Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter).InputObject
   if ($workloadDrops) {
     # Only use the first file to extract the drop name.

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -80,7 +80,15 @@ if ($ci) {
 $versionDetailsPath = (Get-Item "$PSScriptRoot/Version.Details.xml").FullName
 $versionDetailsXml = [Xml.XmlDocument](Get-Content $versionDetailsPath)
 # DropNames is not a value in the Version.Details.xml. We end up adding the drop name(s) after downloading the drops.
-$versionDetails = $versionDetailsXml.Dependencies.ProductDependencies.Dependency | Select-Object -Property Name, Version, Uri, Sha, BarId, DropNames -Unique
+$versionDetailsUnfiltered = $versionDetailsXml.Dependencies.ProductDependencies.Dependency | Select-Object -Property Name, Version, Uri, Sha, BarId, DropNames
+# Only unique entries are needed (based on Sha). If BarId is present, those entries are kept instead of BarId-less entries.
+$versionDetails = $versionDetailsUnfiltered | Group-Object -Property Sha | ForEach-Object {
+  $entries = $_.Group | Where-Object { $_.BarId }
+  if (-not $entries) {
+    $entries = $_.Group | Select-Object -First 1
+  }
+  $entries
+}
 
 # Construct the asset filter to only download the required workload drops.
 $workloadFilter = ''
@@ -170,7 +178,7 @@ if ($downloadWorkloadNupkgs) {
   $filteredWorkloadDropNames = ConvertFrom-Json -InputObject $workloadListJson | Where-Object { $nupkgExcludeList -notcontains $_ }
 
   # Asset filter for .nupkg files, excluding .symbols.nupkg.
-  $nupkgAssetFilter = '(?<!\.symbols\.nupkg)(\.nupkg)$'
+  $nupkgAssetFilter = '(?<!\.symbols)\.nupkg$'
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -172,7 +172,7 @@ if ($downloadWorkloadNupkgs) {
 
   # Asset filter for .nupkg files, excluding .symbols.nupkg.
   # Note: The $ at the end of these filters are required for the positive/negative lookbehinds to function in DARC.
-  $nupkgAssetFilter = '^.*\.nupkg(?<!\.symbols\.nupkg)$'
+  $nupkgAssetFilter = '((\.nupkg)(?<!\.symbols\.nupkg))$'
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -170,9 +170,9 @@ if ($downloadWorkloadNupkgs) {
   $nupkgExcludeList = ConvertFrom-Json -InputObject $workloadNupkgExcludeListJson
   $filteredWorkloadDropNames = ConvertFrom-Json -InputObject $workloadListJson | Where-Object { $nupkgExcludeList -notcontains $_ }
 
-  # Asset filter for .nupkg files, excluding .symbols.nupkg.
+  # Asset filter to include everything except .symbols.nupkg, .zip, and .xml files.
   # Note: The $ at the end of these filters are required for the positive/negative lookbehinds to function in DARC.
-  $nupkgAssetFilter = '((\.nupkg)(?<!\.symbols\.nupkg))$'
+  $nupkgAssetFilter = '(?<!\.symbols\.nupkg)(?<!\.zip)(?<!\.xml)$'
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -150,7 +150,7 @@ $versionDetails | ForEach-Object {
     $workloadDropsAfter = @()
   }
 
-  $fileDelta = Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter -Property FullName
+  $fileDelta = Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter
   if ($fileDelta) {
     $workloadDropFileNames = $fileDelta.InputObject.Name
     # Get the drop name(s) by extracting the name out of the downloaded files.
@@ -162,7 +162,7 @@ $versionDetails | ForEach-Object {
 
 Write-Host 'Workload drops downloaded:'
 # https://stackoverflow.com/a/9570030/294804
-Get-ChildItem $workloadPath -File -Include 'Workload.VSDrop.*.zip' -Recurse | Select-Object -Expand FullName
+Get-ChildItem $workloadPath -File -Include 'Workload.VSDrop.*.zip' -Recurse -ErrorAction SilentlyContinue | Select-Object -Expand FullName
 
 # Download workload .nupkg files if enabled.
 if ($downloadWorkloadNupkgs) {
@@ -177,6 +177,10 @@ if ($downloadWorkloadNupkgs) {
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_
     $versionDetail = $versionDetails | Where-Object { $_.DropNames -contains $dropName } | Select-Object -First 1
+    if (-not $versionDetail) {
+      Write-Host "No version detail found for drop name: $dropName. Skipping .nupkg download for this workload."
+      return
+    }
 
     Write-Host "Downloading .nupkgs for workload: $dropName"
     $nupkgDarcArguments = @(
@@ -213,5 +217,5 @@ if ($downloadWorkloadNupkgs) {
   }
 
   Write-Host 'Workload .nupkgs downloaded:'
-  Get-ChildItem $workloadNupkgPath -File -Include '*.nupkg' -Recurse | Select-Object -Expand FullName
+  Get-ChildItem $workloadNupkgPath -File -Include '*.nupkg' -Recurse -ErrorAction SilentlyContinue | Select-Object -Expand FullName
 }

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -171,7 +171,7 @@ if ($downloadWorkloadNupkgs) {
   $filteredWorkloadDropNames = ConvertFrom-Json -InputObject $workloadListJson | Where-Object { $nupkgExcludeList -notcontains $_ }
 
   # Asset filter for .nupkg files, excluding .symbols.nupkg.
-  $nupkgAssetFilter = '.*(?<!\.symbols)\.nupkg$'
+  $nupkgAssetFilter = '\.nupkg(?<!\.symbols\.nupkg)$'
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -28,25 +28,18 @@ param (
   [Parameter(Mandatory=$true)] [string] $workloadPath,
   [SecureString] $gitHubPat,
   [SecureString] $azDOPat,
-  [string] $workloadListJson = '',
+  [string] $workloadListJson = '[]',
   [bool] $usePreComponents = $false,
   [bool] $includeNonShipping = $false,
   [bool] $downloadWorkloadNupkgs = $false,
-  [string] $workloadNupkgExcludeListJson = '',
+  [string] $workloadNupkgExcludeListJson = '[]',
   [string] $workloadNupkgPath = ''
 )
 
 ## Initialize ##
-if (-not $workloadListJson) {
-  $workloadListJson = '[]';
-}
-if (-not $workloadNupkgExcludeListJson) {
-  $workloadNupkgExcludeListJson = '[]';
-}
 if (-not $workloadNupkgPath) {
   $workloadNupkgPath = "$workloadPath/packages/workloadNupkgs";
 }
-
 $nonShippingFlag = ''
 if ($includeNonShipping) {
   $nonShippingFlag = '--non-shipping'
@@ -178,7 +171,7 @@ if ($downloadWorkloadNupkgs) {
   $filteredWorkloadDropNames = ConvertFrom-Json -InputObject $workloadListJson | Where-Object { $nupkgExcludeList -notcontains $_ }
 
   # Asset filter for .nupkg files, excluding .symbols.nupkg.
-  $nupkgAssetFilter = '*(?<!\.symbols)\.nupkg$'
+  $nupkgAssetFilter = '.*(?<!\.symbols)\.nupkg$'
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -170,9 +170,9 @@ if ($downloadWorkloadNupkgs) {
   $nupkgExcludeList = ConvertFrom-Json -InputObject $workloadNupkgExcludeListJson
   $filteredWorkloadDropNames = ConvertFrom-Json -InputObject $workloadListJson | Where-Object { $nupkgExcludeList -notcontains $_ }
 
-  # Asset filter to include everything except .symbols.nupkg, .zip, and .xml files.
-  # Note: The $ at the end of these filters are required for the positive/negative lookbehinds to function in DARC.
-  $nupkgAssetFilter = '(?<!\.symbols\.nupkg)(?<!\.zip)(?<!\.xml)$'
+  # Asset filter to exclude any asset with a '/' in the name (nested assets).
+  # All root-level packages have an asset name that does NOT include the file extension. These root-level packages ARE the workload .nupkgs we want to download.
+  $nupkgAssetFilter = '^[^/]+$'
 
   $filteredWorkloadDropNames | ForEach-Object {
     $dropName = $_

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -2,21 +2,55 @@
 # In CI, we need to pass PATs to this, so it runs in Azure Pipelines only (not through MSBuild).
 # For local builds, some preconfiguration is necessary. Check the README.md for details.
 
-# $workloadPath: The path to the directory as output for the workload ZIPs. This is --output-dir in the DARC command.
+# $workloadPath: The path to the directory as output for the workload ZIPs. This is --output-dir in the DARC command for the workload drop .zip downloads.
 # - Example Value: "$(RepoRoot)artifacts\workloads"
 # $gitHubPat: The GitHub PAT to use for DARC (CI build only). See workload-build.yml for converting the PAT to SecureString.
 # $azDOPat: The Azure DevOps PAT to use for DARC (CI build only). See workload-build.yml for converting the PAT to SecureString.
 # $workloadListJson: The JSON string of the list of workload drop names to download. If not provided, all workloads found in Version.Details.xml will be downloaded.
 # - See the workloadDropNames parameter in official.yml for the list generally passed to this script.
-# - Example Value: '["emsdk","mono"]'
+# - Example Value: '["iOS","android","maui"]'
 # $usePreComponents:
 # - If $true, includes *pre.components.zip drops and excludes *components.zip drops.
 # - If $false, excludes *pre.components.zip drops and includes *components.zip drops.
 # $includeNonShipping:
 # - If $true, includes workloads that are in the 'non-shipping' folder.
 # - If $false, excludes workloads that are in the 'non-shipping' folder.
+# $downloadWorkloadNupkgs:
+# - If $true, includes downloading the workload .nupkg files.
+# - If $false, excludes downloading the workload .nupkg files.
+# $workloadNupkgExcludeListJson: The JSON string of the list of workload NuGet packages to exclude from downloading. This only applies if $downloadWorkloadNupkgs is $true.
+# - See the workloadNupkgExcludeList parameter in official.yml for the list generally passed to this script.
+# - Example Value: '["emsdk","mono"]'
+# $workloadNupkgPath: The path to the directory for workload .nupkg downloads. This is --output-dir in the DARC command for the .nupkg downloads.
+# - Example Value: "$(RepoRoot)artifacts\packages\workloadNupkgs"
 
-param ([Parameter(Mandatory=$true)] [string] $workloadPath, [SecureString] $gitHubPat, [SecureString] $azDOPat, [string] $workloadListJson = '', [bool] $usePreComponents = $false, [bool] $includeNonShipping = $false)
+param (
+  [Parameter(Mandatory=$true)] [string] $workloadPath,
+  [SecureString] $gitHubPat,
+  [SecureString] $azDOPat,
+  [string] $workloadListJson = '',
+  [bool] $usePreComponents = $false,
+  [bool] $includeNonShipping = $false,
+  [bool] $downloadWorkloadNupkgs = $false,
+  [string] $workloadNupkgExcludeListJson = '',
+  [string] $workloadNupkgPath = '',
+)
+
+## Initialize ##
+if (-not $workloadListJson) {
+  $workloadListJson = '[]';
+}
+if (-not $workloadNupkgExcludeListJson) {
+   $workloadNupkgExcludeListJson = '[]';
+}
+if (-not $workloadNupkgPath) {
+   $workloadNupkgPath = "$workloadPath/packages/workloadNupkgs";
+}
+
+$nonShippingFlag = ''
+if ($includeNonShipping) {
+  $nonShippingFlag = '--non-shipping'
+}
 
 ### Local Build ###
 # Local build requires the installation of DARC. See: https://github.com/dotnet/arcade/blob/main/Documentation/Darc.md#setting-up-your-darc-client
@@ -43,19 +77,18 @@ if ($ci) {
 }
 
 # Reads the Version.Details.xml file to get the workload builds.
-$versionDetailsPath = (Get-Item "$PSScriptRoot\Version.Details.xml").FullName
+$versionDetailsPath = (Get-Item "$PSScriptRoot/Version.Details.xml").FullName
 $versionDetailsXml = [Xml.XmlDocument](Get-Content $versionDetailsPath)
 $versionDetails = $versionDetailsXml.Dependencies.ProductDependencies.Dependency | Select-Object -Property Name, Version, Uri, Sha, BarId -Unique
 
 # Construct the asset filter to only download the required workload drops.
 $workloadFilter = ''
-if ($workloadListJson) {
-  $workloadList = ConvertFrom-Json -InputObject $workloadListJson
-  # Using Length accounts for arrays (multiple workloads provided) and strings (single workload provided).
-  if ($workloadList.Length -ne 0) {
-    $workloadFilter = "($($workloadList | Join-String -Separator '|'))"
-  }
+$workloadList = ConvertFrom-Json -InputObject $workloadListJson
+# Using Length accounts for arrays (multiple workloads provided) and strings (single workload provided).
+if ($workloadList.Length -ne 0) {
+  $workloadFilter = "($($workloadList | Join-String -Separator '|'))"
 }
+
 # Note: The $ at the end of these filters are required for the positive/negative lookbehinds to function.
 # Exclude pre.components.zip.
 $componentFilter = '(?<!pre\.components\.zip)$'
@@ -66,15 +99,11 @@ if ($usePreComponents) {
 $assetFilter = "Workload\.VSDrop\.$workloadFilter.*$componentFilter"
 Write-Host "assetFilter: $assetFilter"
 
-$nonShippingFlag = ''
-if ($includeNonShipping) {
-  $nonShippingFlag = '--non-shipping'
-}
-
 # Runs DARC against each workload build to download the drops (if applicable based on the filter).
 $versionDetails | ForEach-Object {
   Write-Host "Dependency name: $($_.Name)"
   Write-Host "Dependency version: $($_.Version)"
+
   $darcArguments = @(
     'gather-drop'
     '--asset-filter'
@@ -88,7 +117,7 @@ $versionDetails | ForEach-Object {
     $nonShippingFlag
   )
 
-  $buildDropArguments = @(
+  $darcBuildArguments = @(
     '--repo'
     $_.Uri
     '--commit'
@@ -96,18 +125,74 @@ $versionDetails | ForEach-Object {
   )
 
   if ($_.BarId) {
-    $buildDropArguments = @(
+    $darcBuildArguments = @(
       '--id'
       $_.BarId
     )
   }
 
   Write-Host "darcArguments: $($darcArguments | Join-String -Separator ' ')"
-  Write-Host "buildDropArguments: $($buildDropArguments | Join-String -Separator ' ')"
+  Write-Host "darcBuildArguments: $($darcBuildArguments | Join-String -Separator ' ')"
 
-  & $darc ($darcArguments + $buildDropArguments + $ciArguments)
+  & $darc ($darcArguments + $darcBuildArguments + $ciArguments)
 }
 
 Write-Host 'Workload drops downloaded:'
 # https://stackoverflow.com/a/9570030/294804
 Get-ChildItem $workloadPath -File -Include 'Workload.VSDrop.*.zip' -Recurse | Select-Object -Expand FullName
+
+# Download workload .nupkg files if enabled.
+if ($downloadWorkloadNupkgs) {
+  # Build the list of workloads to download nupkgs for, excluding items in the exclude list.
+  $nupkgExcludeList = ConvertFrom-Json -InputObject $workloadNupkgExcludeListJson
+  $filteredWorkloadDropNames = ConvertFrom-Json -InputObject $workloadListJson | Where-Object { $nupkgExcludeList -notcontains $_ }
+
+  # Asset filter for .nupkg files, excluding .symbols.nupkg.
+  $nupkgAssetFilter = '(?<!\.symbols\.nupkg)(\.nupkg)$'
+
+  $filteredWorkloadDropNames | ForEach-Object {
+    # Check if the workload drop path contains any files with this workload name in the filename.
+    $dropName = $_
+    $workloadDrops = Get-ChildItem $workloadPath -File -Recurse | Where-Object { $_.Name -match $dropName }
+    if ($workloadDrops) {
+      Write-Host "Downloading .nupkgs for workload: $dropName"
+
+      $workloadDrops | ForEach-Object {
+        $nupkgDarcArguments = @(
+          'gather-drop'
+          '--asset-filter'
+          $nupkgAssetFilter
+          '--output-dir'
+          $workloadNupkgPath
+          '--include-released'
+          '--skip-existing'
+          '--continue-on-error'
+          '--use-azure-credential-for-blobs'
+          $nonShippingFlag
+        )
+
+        $nupkgDarcBuildArguments = @(
+          '--repo'
+          $_.Uri
+          '--commit'
+          $_.Sha
+        )
+
+        if ($_.BarId) {
+          $nupkgDarcBuildArguments = @(
+            '--id'
+            $_.BarId
+          )
+        }
+
+        Write-Host "nupkgDarcArguments: $($nupkgDarcArguments | Join-String -Separator ' ')"
+        Write-Host "nupkgDarcBuildArguments: $($nupkgDarcBuildArguments | Join-String -Separator ' ')"
+
+        & $darc ($nupkgDarcArguments + $nupkgDarcBuildArguments + $ciArguments)
+      }
+    }
+  }
+
+  Write-Host 'Workload .nupkgs downloaded:'
+  Get-ChildItem $workloadNupkgPath -File -Include '*.nupkg' -Recurse | Select-Object -Expand FullName
+}

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -33,7 +33,7 @@ param (
   [bool] $includeNonShipping = $false,
   [bool] $downloadWorkloadNupkgs = $false,
   [string] $workloadNupkgExcludeListJson = '',
-  [string] $workloadNupkgPath = '',
+  [string] $workloadNupkgPath = ''
 )
 
 ## Initialize ##

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -149,8 +149,9 @@ $versionDetails | ForEach-Object {
     $workloadDropsAfter = @()
   }
 
-  $workloadDropFileNames = (Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter).InputObject.Name
-  if ($workloadDropFileNames) {
+  $fileDelta = Compare-Object -ReferenceObject $workloadDropsBefore -DifferenceObject $workloadDropsAfter
+  if ($fileDelta) {
+    $workloadDropFileNames = $fileDelta.InputObject.Name
     # Get the drop name(s) by extracting the name out of the downloaded files.
     # DropNames are needed for the workload .nupkg download process below.
     $_.DropNames = $workloadDropFileNames | ForEach-Object { if ($_ -match 'Workload\.VSDrop\.([^.]+)\.') { $Matches[1] } } | Select-Object -Unique

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -22,19 +22,19 @@ parameters:
   type: boolean
   default: false
 - name: publishToAzDO
-  displayName: Publish to AzDO
+  displayName: Publish package(s) to AzDO
   type: boolean
   default: false
 - name: azDOPublishFeed
   displayName: AzDO publish feed
   type: string
   default: public/dotnet-workloads
-- name: publishWorkloadNupkgsToAzDO
-  displayName: Publish workload packages to AzDO
+- name: downloadWorkloadNupkgs
+  displayName: Download workload packages (.nupkg)
   type: boolean
   default: false
 - name: workloadNupkgExcludeList
-  displayName: Exclude workload packages from publish
+  displayName: Exclude workload packages (.nupkg)
   type: object
   default:
   - emsdk
@@ -212,7 +212,7 @@ extends:
           setVersionPatch: ${{ parameters.setVersionPatch }}
           setPreReleaseVersionLabel: ${{ parameters.setPreReleaseVersionLabel }}
           setPreReleaseVersionIteration: ${{ parameters.setPreReleaseVersionIteration }}
-          downloadWorkloadNupkgs: ${{ parameters.publishWorkloadNupkgsToAzDO }}
+          downloadWorkloadNupkgs: ${{ parameters.downloadWorkloadNupkgs }}
           workloadNupkgExcludeList: ${{ parameters.workloadNupkgExcludeList }}
 
     - ${{ if eq(parameters.createVSInsertion, true) }}:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -29,6 +29,16 @@ parameters:
   displayName: AzDO publish feed
   type: string
   default: public/dotnet-workloads
+- name: publishWorkloadNupkgsToAzDO
+  displayName: Publish workload packages to AzDO
+  type: boolean
+  default: false
+- name: workloadNupkgExcludeList
+  displayName: Exclude workload packages from publish
+  type: object
+  default:
+  - emsdk
+  - mono
 
 - name: dividerVSInsertion
   displayName: '[ ######## VS INSERTION ######## ]'
@@ -202,6 +212,8 @@ extends:
           setVersionPatch: ${{ parameters.setVersionPatch }}
           setPreReleaseVersionLabel: ${{ parameters.setPreReleaseVersionLabel }}
           setPreReleaseVersionIteration: ${{ parameters.setPreReleaseVersionIteration }}
+          downloadWorkloadNupkgs: ${{ parameters.publishWorkloadNupkgsToAzDO }}
+          workloadNupkgExcludeList: ${{ parameters.workloadNupkgExcludeList }}
 
     - ${{ if eq(parameters.createVSInsertion, true) }}:
       - stage: Insertion

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -56,7 +56,7 @@ jobs:
         displayName: 🟣 Set run name via source branch commit message
         # Name is required to reference the variables created within this build step in other stages.
         name: SetRunName
-      - ${{ if eq(parameters.createVSInsertion, true) }}:
+      - ${{ if or(eq(parameters.createVSInsertion, true), eq(parameters.downloadWorkloadNupkgs, true) }}:
         # The convertToJson expression in AzDO creates "pretty" JSON with line breaks and indentation.
         # To simplify passing this JSON to scripts, we collapse it to a single line.
         - powershell: |
@@ -76,7 +76,7 @@ jobs:
             Write-Host "##vso[task.setvariable variable=WorkloadNupkgExcludeListJson]$workloadNupkgExcludeListJson"
           displayName: 🟣 Set WorkloadNupkgExcludeListJson variable
         - task: AzureCLI@2
-          displayName: 🟣 Download workloads for VS insertion
+          displayName: 🟣 Download workloads
           inputs:
             azureSubscription: DotNetStaging
             scriptType: pscore

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -91,7 +91,7 @@ jobs:
               -includeNonShipping:$${{ parameters.includeNonShippingWorkloads }}
               -downloadWorkloadNupkgs:$${{ parameters.downloadWorkloadNupkgs }}
               -WorkloadNupkgExcludeListJson '$(WorkloadNupkgExcludeListJson)'
-              -workloadNupkgPath '$(System.DefaultWorkingDirectory)artifacts/packages/workloadNupkgs'
+              -workloadNupkgPath '$(System.DefaultWorkingDirectory)/artifacts/packages/workloadNupkgs'
       - powershell: eng/create-version-override.ps1
           -createTestWorkloadSet:$${{ parameters.createTestWorkloadSet }}
           -versionSdkMinor '${{ parameters.setVersionSdkMinor }}'

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -56,7 +56,7 @@ jobs:
         displayName: 🟣 Set run name via source branch commit message
         # Name is required to reference the variables created within this build step in other stages.
         name: SetRunName
-      - ${{ if or(eq(parameters.createVSInsertion, true), eq(parameters.downloadWorkloadNupkgs, true) }}:
+      - ${{ if or(eq(parameters.createVSInsertion, true), eq(parameters.downloadWorkloadNupkgs, true)) }}:
         # The convertToJson expression in AzDO creates "pretty" JSON with line breaks and indentation.
         # To simplify passing this JSON to scripts, we collapse it to a single line.
         - powershell: |

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -66,6 +66,15 @@ jobs:
             $workloadListJson = $workloadDropNames -replace '\r?\n\s*', ''
             Write-Host "##vso[task.setvariable variable=WorkloadListJson]$workloadListJson"
           displayName: 🟣 Set WorkloadListJson variable
+        # The convertToJson expression in AzDO creates "pretty" JSON with line breaks and indentation.
+        # To simplify passing this JSON to scripts, we collapse it to a single line.
+        - powershell: |
+            $workloadNupkgExcludeList = @'
+            ${{ convertToJson(parameters.workloadNupkgExcludeList) }}
+            '@
+            $workloadNupkgExcludeListJson = $workloadNupkgExcludeList -replace '\r?\n\s*', ''
+            Write-Host "##vso[task.setvariable variable=WorkloadNupkgExcludeListJson]$workloadNupkgExcludeListJson"
+          displayName: 🟣 Set WorkloadNupkgExcludeListJson variable
         - task: AzureCLI@2
           displayName: 🟣 Download workloads for VS insertion
           inputs:
@@ -80,6 +89,9 @@ jobs:
               -workloadListJson '$(WorkloadListJson)'
               -usePreComponents:$${{ parameters.usePreComponentsForVSInsertion }}
               -includeNonShipping:$${{ parameters.includeNonShippingWorkloads }}
+              -downloadWorkloadNupkgs:$${{ parameters.downloadWorkloadNupkgs }}
+              -WorkloadNupkgExcludeListJson '$(WorkloadNupkgExcludeListJson)'
+              -workloadNupkgPath '$(System.DefaultWorkingDirectory)artifacts/packages/workloadNupkgs'
       - powershell: eng/create-version-override.ps1
           -createTestWorkloadSet:$${{ parameters.createTestWorkloadSet }}
           -versionSdkMinor '${{ parameters.setVersionSdkMinor }}'


### PR DESCRIPTION
Related: https://github.com/dotnet/workload-versions/pull/749

## Summary
The `download-workloads.ps1` process currently is used for VS insertion. This changes that script to also download the .nupkg files from the DARC build when necessary. These .nupkg files will be output to: `$(System.DefaultWorkingDirectory)/artifacts/packages/workloadNupkgs`. Therefore, if you want to publish those packages (along with the workload set .nupkg), you just check the `Publish package(s) to AzDO` checkbox, and it'll also publish the workload .nupkgs to the feed. The publish process include all nested .nupkg files within the `packages` folder. Additionally (**untested**), `🚨 Publish to NuGet.org` should also work as it simply publishes the .nupkgs in the `packages` folder (same as AzDO publish). So, it should *just work*. 😅

## Changes
- Added a `Download workload packages (.nupkg)` checkbox that will allow the `download-workloads.ps1` to acquire the .nupkg files from the DARC build.
- Added a `Exclude workload packages (.nupkg)` list that does not acquire .nupkgs from the DARC build when the download checkbox is checked. This is defaulted to exclude `emsdk` and `mono`.
- In `download-workloads.ps1`:
  - Cleaned up missing defaulted parameters to include an empty set (or actual default value)
  - Better unique filtering for DARC builds via the `Version.Details.xml` file
  - Compute associated drop name(s) per dependency from the `Version.Details.xml` file
  - Added process for using drop names (and associated dependency info) to acquire .nupkg files from a DARC build

## Notes
I originally wanted to only run the DARC command once per dependency, but the issue was that there is no direct correlation between the drop name (maui, iOS, android, emsdk, mono) and their associated dependency in the Version.Details.xml. So, to compute this, we notice if the first set of DARC calls for downloading the drop (.zip) actually acquired any files. If it does, that means the dependency has drop name(s) associated with it. The reason a single dependency can have multiple drop names is because the `dotnet/dotnet` dependency actually has both `emsdk` and `mono` drops within it. So, that's a one-to-many association. I've coded this solution to account for that. Lastly, we extract the drop name out of the files downloaded and use that as the unique set of drop names for that dependency.

With that information in-hand, then the second set of DARC calls goes through the list of filtered drop names (full list from `$workloadListJson` and then filtering the excludes from `$workloadNupkgExcludeListJson`). Then, we grab the associated dependency info that relates to that drop name, and run the DARC command to download the .nupkg files from the build. The workload .nupkg files are those assets that are NOT nested (meaning, have no `/` in the name). Additionally, assets at the package root also do not contain a file extension (no `.nupkg`) as the ASSET NAME. So, we filter out all nested assets (asset name containing `/`). This will download all root-level packages (which are the workload .nupkgs). When downloaded, the files do contain the proper .nupkg file extension.