### PR TITLE
Replace dn-bot-all-drop-rw-code-rw-release-all PAT with WIF token

### DIFF
--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -80,18 +80,19 @@ jobs:
           inputs:
             azureSubscription: DotNetStaging
             scriptType: pscore
-            scriptPath: $(System.DefaultWorkingDirectory)/eng/download-workloads.ps1
-            # Note: The second $ for usePreComponents and includeNonShipping allows the value to resolve as `$true` or `$false`.
-            arguments: >-
-              -workloadPath '$(System.DefaultWorkingDirectory)/artifacts/workloads'
-              -gitHubPat (ConvertTo-SecureString -String '$(BotAccount-dotnet-bot-repo-PAT)' -AsPlainText -Force)
-              -azDOPat (ConvertTo-SecureString -String '$(dn-bot-all-drop-rw-code-rw-release-all)' -AsPlainText -Force)
-              -workloadListJson '$(WorkloadListJson)'
-              -usePreComponents:$${{ parameters.usePreComponentsForVSInsertion }}
-              -includeNonShipping:$${{ parameters.includeNonShippingWorkloads }}
-              -downloadWorkloadNupkgs:$${{ parameters.downloadWorkloadNupkgs }}
-              -WorkloadNupkgExcludeListJson '$(WorkloadNupkgExcludeListJson)'
-              -workloadNupkgPath '$(System.DefaultWorkingDirectory)/artifacts/packages/workloadNupkgs'
+            scriptLocation: inlineScript
+            inlineScript: |
+              $azDOToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+              & '$(System.DefaultWorkingDirectory)/eng/download-workloads.ps1' `
+                -workloadPath '$(System.DefaultWorkingDirectory)/artifacts/workloads' `
+                -gitHubPat (ConvertTo-SecureString -String '$(BotAccount-dotnet-bot-repo-PAT)' -AsPlainText -Force) `
+                -azDOPat (ConvertTo-SecureString -String $azDOToken -AsPlainText -Force) `
+                -workloadListJson '$(WorkloadListJson)' `
+                -usePreComponents:$${{ parameters.usePreComponentsForVSInsertion }} `
+                -includeNonShipping:$${{ parameters.includeNonShippingWorkloads }} `
+                -downloadWorkloadNupkgs:$${{ parameters.downloadWorkloadNupkgs }} `
+                -WorkloadNupkgExcludeListJson '$(WorkloadNupkgExcludeListJson)' `
+                -workloadNupkgPath '$(System.DefaultWorkingDirectory)/artifacts/packages/workloadNupkgs'
       - powershell: eng/create-version-override.ps1
           -createTestWorkloadSet:$${{ parameters.createTestWorkloadSet }}
           -versionSdkMinor '${{ parameters.setVersionSdkMinor }}'


### PR DESCRIPTION
## Summary

Migrate the Download workloads AzureCLI@2 task from using the `dn-bot-all-drop-rw-code-rw-release-all` PAT to acquiring an AzDO access token from the **DotNetStaging** service connection via `az account get-access-token`.

## What changed

The task already runs with the DotNetStaging service connection (WIF). Instead of passing the PAT variable, we now:
1. Acquire an AzDO token: `az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798`
2. Convert to SecureString and pass to `download-workloads.ps1 -azDOPat`

This switches from `scriptPath`+`arguments` to `inlineScript` to allow the token acquisition step.

## Why

Part of the 1ES PAT Disable Policy migration. The `dn-bot-all-drop-rw-code-rw-release-all` PAT is being retired in favor of Entra-based authentication.

Tracked by: https://dev.azure.com/dnceng/internal/_workitems/edit/10105

## Validation

- The DotNetStaging SP is already enrolled in the `dnceng` AzDO org with appropriate group memberships
- The SP already authenticates blob storage downloads in these same tasks
- Post-merge, monitor the first workload-versions official pipeline run to confirm end-to-end
