### PR TITLE
Workaround MSB4216: add Architecture=* to InstallDotNetCore UsingTask

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,6 +2,16 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <!-- Workaround: Arcade SDK declares InstallDotNetCore with Runtime="NET" but no Architecture,
+       causing MSB4216 when the host MSBuild is x86 (no x86 .NET task host exists).
+       Architecture="*" lets MSBuild use any available architecture.
+       Remove once dotnet/arcade includes this fix. -->
+  <UsingTask Condition="'$(ArcadeSdkBuildTasksAssembly)' != ''"
+             TaskName="Microsoft.DotNet.Arcade.Sdk.InstallDotNetCore"
+             AssemblyFile="$(ArcadeSdkBuildTasksAssembly)"
+             Runtime="NET"
+             Architecture="*" />
+
   <PropertyGroup>
     <!-- Need to update the workloads version after the arcade targets have run -->
     <WorkloadsVersion Condition="'$(VersionSuffix)' != ''">$(WorkloadsVersion)-$(VersionSuffix)</WorkloadsVersion>


### PR DESCRIPTION
## Problem

The Arcade SDK 11.0.0-beta declares the \InstallDotNetCore\ task with \Runtime=\"NET\"\ but no \Architecture\ attribute in \BuildTasks.props\. When the host MSBuild is x86 (e.g., VS 18 Insiders default), MSBuild tries to create an x86 .NET task host, but the .NET SDK only ships x64 binaries, causing:

\\\
error MSB4216: Could not run the \"InstallDotNetCore\" task because MSBuild could not create or connect to a task host with runtime \"NET\" and architecture \"x86\".
\\\

## Fix

Override the \InstallDotNetCore\ \UsingTask\ in \Directory.Build.targets\ (after the Arcade SDK import) with \Architecture=\"*\"\, which lets MSBuild use any available architecture.

## Tracking

The root cause fix belongs in \dotnet/arcade\. This workaround should be removed once Arcade ships the fix.
