### PR TITLE
Disable AddCommitsToPR on VS insertion to avoid spurious build failures

### DIFF
--- a/eng/pipelines/templates/steps/workload-insertion-steps.yml
+++ b/eng/pipelines/templates/steps/workload-insertion-steps.yml
@@ -44,7 +44,12 @@ steps:
     InsertionReviewers: Dotnet Core SDK and CLI
     InsertionBuildPolicies: Request Perf DDRITs
     # Documentation: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/631/Copy-Commit-Details-to-PR
-    AddCommitsToPR: true
+    # Disabled: this feature's "Copy Commit Details to PR" step fatally fails the task *after* the insertion PR
+    # is already created when it cannot compute a commit diff (e.g. the metadata service has no bearer token and
+    # the legacy fallback selects a same-commit sibling build as the baseline, yielding "No changes found").
+    # The commits for these insertions are version-number updates rather than meaningful code changes, so the
+    # auto-generated commit list adds little value and isn't worth failing the build over.
+    AddCommitsToPR: false
     # Documentation: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/634/Link-Work-Items-to-PR
     LinkWorkItemsToPR: false
     # Documentation: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/638/Set-AutoComplete-on-an-Insertion


### PR DESCRIPTION
## What

Set `AddCommitsToPR: false` for the MicroBuild **Insert VS Payload** task in `eng/pipelines/templates/steps/workload-insertion-steps.yml`.

## Why

In build [3009141](https://dev.azure.com/dnceng/internal/_build/results?buildId=3009141) the VS insertion **succeeded** — the PR ([DevDiv #753336](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/753336)) was created — but the task then **failed with exit code 1** on the post-PR "Copy Commit Details to PR" step:

```
##[error]No changes found between 20260626.3 and 20260626.2 ...
```

### Root cause
The `AddCommitsToPR` feature tries to compute the list of commits to paste into the PR description *after* the PR already exists, and treats failure as fatal. Two environmental factors triggered it:

1. `No ADO bearer token is available to call the metadata service` — so it fell back to legacy "previous build" logic.
2. The legacy fallback selected a **canceled, same-commit sibling build** (`20260626.3`, build 3009185, same source commit `7ed63c0f`) as the diff baseline → empty diff → fatal `No changes found`.

So a cosmetic, post-PR description step is failing builds even though the insertion itself worked.

### Why disabling is acceptable
The commits rolled into these insertions are **version-number updates, not meaningful code changes**, so the auto-generated commit list adds little value and isn't worth failing the build over. The information is still discoverable from the component-version diff and this repo's history.

## Impact
- ✅ Insertion PR, reviewers, build policies, and auto-complete are unchanged.
- ➖ The VS PR description will no longer include the auto-populated source-commit list.

## Follow-ups (not in this PR)
- File a MicroBuild bug: "Copy Commit Details to PR" should not fatally fail the task after the PR is created, and the metadata-service bearer-token issue should be addressed.
- Reduce concurrent/duplicate same-commit runs of the official-ci pipeline to avoid poisoning the diff baseline.
