### PR TITLE
Replace Release-Pipeline variable group with DotNetBot-GitHub-AllBranches

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -151,12 +151,7 @@ variables:
 ############### GROUPS ###############
 # Provides TSA variables for automatic bug reporting.
 - group: DotNet-CLI-SDLValidation-Params
-# Release-Pipeline provides: BotAccount-dotnet-bot-repo-PAT, dn-bot-all-drop-rw-code-rw-release-all
-# https://dnceng.visualstudio.com/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=87&path=Release-Pipeline
-- group: Release-Pipeline
-# DotNet-DevDiv-Insertion-Workflow-Variables provides: dn-bot-devdiv-drop-rw-code-rw
-# https://dnceng.visualstudio.com/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=33&path=DotNet-DevDiv-Insertion-Workflow-Variables
-- group: DotNet-DevDiv-Insertion-Workflow-Variables
+- group: DotNetBot-GitHub-AllBranches
 
 resources:
   repositories:


### PR DESCRIPTION
## Summary

Replaces the `Release-Pipeline` and `DotNet-DevDiv-Insertion-Workflow-Variables` variable groups with `DotNetBot-GitHub-AllBranches` in `eng/pipelines/official.yml`.

## Why

Both `Release-Pipeline` and `DotNet-DevDiv-Insertion-Workflow-Variables` are Azure Key Vault-backed variable groups that fetch **all** listed secrets on every build — including `dn-bot-all-drop-rw-code-rw-release-all` and other PATs that this pipeline doesn't use. This causes the PAT to show as 'in use' in pipeline audits despite being migrated to WIF.

The only secret this pipeline actually needs is `BotAccount-dotnet-bot-repo-PAT`, which `DotNetBot-GitHub-AllBranches` provides.

## Impact

- Stops unnecessary PAT fetching from Key Vault
- Unblocks final deprecation of `dn-bot-all-drop-rw-code-rw-release-all`

Part of: https://dev.azure.com/dnceng/internal/_workitems/edit/10105