### PR TITLE
Support the WiX 6 toolset for workload set MSIs

### DIFF
--- a/src/Microsoft.NET.Workloads/Microsoft.NET.Workloads.csproj
+++ b/src/Microsoft.NET.Workloads/Microsoft.NET.Workloads.csproj
@@ -24,15 +24,38 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
+  <!--
+    CreateVisualStudioWorkloadSet moved from the WiX 3 toolset to the WiX 6 CLI in Arcade 11:
+    the WixToolsetPath parameter was replaced by WixExe/HeatExe/WixExtensions. That change is
+    not being backported, so this project supports both. Source branches default to the legacy
+    WiX 3 toolset and opt out by setting UseWixToolset3 to false once their Arcade dependency
+    is new enough. The flag is named after the legacy toolset so it survives future WiX
+    upgrades: only the modern path below has to change when WiX 7, 8, etc. come along.
+  -->
+  <PropertyGroup>
+    <UseWixToolset3 Condition="'$(UseWixToolset3)' == ''">true</UseWixToolset3>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Signed.WiX" Version="$(WixPackageVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" Version="$(SwixPackageVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Workloads" Version="$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(UseWixToolset3)' == 'true'">
+    <PackageReference Include="Microsoft.Signed.WiX" Version="$(WixPackageVersion)" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseWixToolset3)' != 'true'">
+    <!-- The WiX CLI ships as a tool package, so its assets have to be excluded. -->
+    <PackageReference Include="Microsoft.Wix" Version="$(MicrosoftWixToolsetSdkVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Heat" Version="$(MicrosoftWixToolsetSdkVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Dependency.wixext" Version="$(MicrosoftWixToolsetSdkVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.UI.wixext" Version="$(MicrosoftWixToolsetSdkVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Util.wixext" Version="$(MicrosoftWixToolsetSdkVersion)" GeneratePathProperty="true" />
+  </ItemGroup>
+
   <PropertyGroup>
-    <WixToolsetPath>$(PkgMicrosoft_Signed_Wix)\tools</WixToolsetPath>
     <SwixPluginPath>$(PkgMicrosoft_VisualStudioEng_MicroBuild_Plugins_SwixBuild)</SwixPluginPath>
     <SwixBuildTargets>$(SwixPluginPath)\build\Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild.targets</SwixBuildTargets>
     <WorkloadIntermediateOutputPath>$(ArtifactsObjDir)workloads/</WorkloadIntermediateOutputPath>
@@ -40,13 +63,27 @@
     <VSTemp>$(WorkloadIntermediateOutputPath)VS/</VSTemp>
   </PropertyGroup>
 
-  <!-- Arcade -->
-  <PropertyGroup>
+  <!-- Legacy WiX 3 toolset -->
+  <PropertyGroup Condition="'$(UseWixToolset3)' == 'true'">
+    <WixToolsetPath>$(PkgMicrosoft_Signed_Wix)\tools</WixToolsetPath>
     <!-- Temp directory for light command layouts -->
     <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
     <!-- Directory for the zipped up light command package -->
     <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
   </PropertyGroup>
+
+  <!-- Current WiX toolset -->
+  <PropertyGroup Condition="'$(UseWixToolset3)' != 'true'">
+    <WixExe>$(PkgMicrosoft_Wix)\tools\net6.0\any\wix.exe</WixExe>
+    <HeatExe>$(PkgMicrosoft_WixToolset_Heat)\tools\net472\x64\heat.exe</HeatExe>
+    <WixExtensionsDir>wixext6</WixExtensionsDir>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UseWixToolset3)' != 'true'">
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_Dependency_wixext)\$(WixExtensionsDir)\WixToolset.Dependency.wixext.dll" />
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_UI_wixext)\$(WixExtensionsDir)\WixToolset.UI.wixext.dll" />
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_Util_wixext)\$(WixExtensionsDir)\WixToolset.Util.wixext.dll" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="$(OutputPath)microsoft.net.workloads.workloadset.json" Pack="true" PackagePath="data" />
@@ -107,11 +144,23 @@
       <WorkloadSetPackage Include="$(ArtifactsShippingPackagesDir)/$(PackageId).$(PackageVersion).nupkg" />
     </ItemGroup>
 
-    <CreateVisualStudioWorkloadSet
+    <CreateVisualStudioWorkloadSet Condition="'$(UseWixToolset3)' == 'true'"
         BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
         BaseOutputPath="$(WorkloadOutputPath)"
         WorkloadSetPackageFiles="@(WorkloadSetPackage)"
         WixToolsetPath="$(WixToolsetPath)"
+        WorkloadSetMsiVersion="$(MsiVersion)">
+      <Output TaskParameter="SwixProjects" ItemName="SwixProjects" />
+      <Output TaskParameter="Msis" ItemName="Msis" />
+    </CreateVisualStudioWorkloadSet>
+
+    <CreateVisualStudioWorkloadSet Condition="'$(UseWixToolset3)' != 'true'"
+        BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
+        BaseOutputPath="$(WorkloadOutputPath)"
+        WorkloadSetPackageFiles="@(WorkloadSetPackage)"
+        HeatExe="$(HeatExe)"
+        WixExe="$(WixExe)"
+        WixExtensions="@(WixExtensions)"
         WorkloadSetMsiVersion="$(MsiVersion)">
       <Output TaskParameter="SwixProjects" ItemName="SwixProjects" />
       <Output TaskParameter="Msis" ItemName="Msis" />
@@ -134,8 +183,14 @@
     <ZipDirectory Overwrite="true" SourceDirectory="%(SourceDirectory)"
                   DestinationFile="$(VisualStudioSetupInsertionPath)%(VSDrop.Identity)" />
 
-    <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
-    <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />
+    <!-- WiX 3: gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
+    <MSBuild Condition="'$(UseWixToolset3)' == 'true'"
+             Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />
+
+    <!-- WiX 6 and later: the task generates the wixpacks itself, so they only need to be copied for post-build signing. -->
+    <MakeDir Condition="'$(UseWixToolset3)' != 'true'" Directories="$(ArtifactsNonShippingPackagesDir)" />
+    <Copy Condition="'$(UseWixToolset3)' != 'true'"
+          SourceFiles="%(Msis.WixPack)" DestinationFolder="$(ArtifactsNonShippingPackagesDir)" />
 
     <!-- We disable PackageValidation which runs because these projects import the repo's Directory.Build.props and Directory.Build.targets file. -->
     <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir);IncludeSymbols=false;EnablePackageValidation=false" Targets="restore;pack" />


### PR DESCRIPTION
Arcade 11 migrated `CreateVisualStudioWorkloadSet` from the WiX 3 toolset to the WiX 6 CLI, replacing the `WixToolsetPath` parameter with `WixExe`/`HeatExe`/`WixExtensions`. Building against the newer Arcade fails with:

```
src\Microsoft.NET.Workloads\Microsoft.NET.Workloads.csproj(114,9): error MSB4064: The "WixToolsetPath" parameter is not supported by the "CreateVisualStudioWorkloadSet" task loaded from assembly: Microsoft.DotNet.Build.Tasks.Workloads, Version=11.0.14.37906 ...
src\Microsoft.NET.Workloads\Microsoft.NET.Workloads.csproj(110,5): error MSB4063: The "CreateVisualStudioWorkloadSet" task could not be initialized with its input parameters.
```

This is currently blocking dependency flow to `main`: #878.

## Why both toolsets

This `src` directory is shared by every source branch, and the Arcade change is not being backported — `release/8.0`, `release/9.0` and `release/10.0` of dotnet/arcade all still have `WixToolsetPath`:

| Source branch | Arcade | `CreateVisualStudioWorkloadSet` |
|---|---|---|
| `main` + #878 | 11.0.0-beta.26378.106 | new (`WixExe`) |
| `main` (today) | 11.0.0-beta.26359.118 | old (`WixToolsetPath`) |
| `release/10` | 10.0.0-beta.26371.2 | old |
| `release/9.0.1xx` | 9.0.0-beta.26372.8 | old |
| `release/8.0.4xx` | 8.0.0-beta.26371.5 | old |

So both have to work side by side. Each source branch opts out of the legacy toolset via `UseWixToolset3` once its Arcade dependency is new enough. It defaults to `true`, so **this PR is a no-op until a branch sets it to `false`** — `main` will do that alongside the Arcade bump.

The flag is deliberately named after the *legacy* toolset rather than the new one ([per @joeloff](https://github.com/dotnet/workload-versions/pull/881#discussion_r3676163148)): WiX 7 is expected around the end of the year and WiX 8 in early 2027, so a `UseWixToolset6`-style name would need renaming on every upgrade. With this naming only the modern code path has to change.

## Changes

For the current (WiX 6+) path:

- Replace `Microsoft.Signed.WiX` with the `Microsoft.Wix` CLI, `Microsoft.WixToolset.Heat` and the WiX 6 extensions. Versions come from Arcade's `MicrosoftWixToolsetSdkVersion` default (`6.0.3-dotnet.6`), and the packages are already on the dotnet-eng feed in NuGet.config.
- Pass `WixExe`/`HeatExe`/`WixExtensions` to the task.
- Skip the `CreateWixPack` target — `CreateLightCommandPackageDrop` is WiX 3 only. The task now builds wixpacks itself and exposes them through `%(Msis.WixPack)`, so they only need to be copied for post-build signing.

The task is invoked twice under conditions because MSBuild can't conditionalize an individual attribute. MSB4064 is raised at parameter-bind time, so the invocation whose condition is `false` is skipped safely.

## Validation

Both paths were built locally against a CI-equivalent tree (source branch content with this `src` copied over it, as `workload-checkout.yml` does):

| Scenario | Arcade | `UseWixToolset3` | Result |
|---|---|---|---|
| `main` HEAD | 26359.118 (old) | unset (default `true`) | ✅ 3 MSIs, 3 wixpacks, VSDrop |
| #878 | 26378.106 (new) | `false` | ✅ 3 MSIs, 3 wixpacks, VSDrop |

Artifacts are identical between the two: `x86`/`x64`/`arm64` MSIs, matching `.wixpack.zip` files for signing, the VS insertion drop and all four nupkgs.

Both paths are also covered in real CI by two draft test PRs. Each points its `eng` repository resource at this branch, so the pipeline builds their content against this `src`:

| Test PR | Based on | Target | `UseWixToolset3` | Covers |
|---|---|---|---|---|
| #883 | #878 (Arcade 26378.106) | `main` | `false` | current WiX 6 path |
| #882 | `release/10` (Arcade 10.0.0-beta.26371.2) | `release/10` | unset (default `true`) | legacy WiX 3 path, no regression |

Neither is intended to merge — both are throwaway CI probes and should be closed once this PR is validated.
