### PR TITLE
[TEST - DO NOT MERGE] Validate WiX 3 path unchanged for #881

### DIFF
--- a/eng/pipelines/public.yml
+++ b/eng/pipelines/public.yml
@@ -14,7 +14,7 @@ resources:
   - repository: eng
     type: github
     name: dotnet/workload-versions
-    ref: refs/heads/eng
+    ref: refs/heads/jonathanpeppers-wix6-workload-set-msi
     # Service connection: https://dev.azure.com/dnceng-public/public/_settings/adminservices?resourceId=690f39b4-7746-42c2-be89-281bd7c78b9e
     endpoint: public
 


### PR DESCRIPTION
## ⚠️ THROWAWAY CI PROBE — MUST NEVER BE MERGED ⚠️

This is a disposable test PR whose only purpose is to run real CI against PR #881 (`jonathanpeppers-wix6-workload-set-msi`, targeting `eng`) with the new `UseWixToolset6` flag **OFF** (its default).

### Mechanism under test

This repo splits build logic (`eng` branch: `src/`, `Directory.Build.props`, pipeline templates) from version/manifest data (`main`, `release/*`). `eng/pipelines/public.yml` declares an `eng` repository resource, and Azure Pipelines reads the YAML from a PR's **source** branch. So the single change here:

```diff
-    ref: refs/heads/eng
+    ref: refs/heads/jonathanpeppers-wix6-workload-set-msi
```

makes this `release/10` build compile against PR #881's `src/` instead of `eng` HEAD.

### Why no flag is set

`UseWixToolset6` is deliberately **not** set anywhere. `release/10` uses Arcade 10.0.0-beta.26371.2, whose `CreateVisualStudioWorkloadSet` task still takes `WixToolsetPath` (the Arcade 11 change was not backported to `release/8.0`/`release/9.0`/`release/10.0`). Since `eng`'s `src/` is shared by every source branch, #881 must be a no-op for branches that have not opted in. This PR proves that.

### Expected outcome

Green build, identical to a normal `release/10` build today: x86/x64/arm64 MSIs, three `.wixpack.zip` files, and the VS insertion drop.

### Scope

Exactly one line changed. Nothing in `src/` touched.

**Do not merge. Close and delete the branch once #881 is validated.**