### PR TITLE
Use GitHub App for workload artifact downloads

### DIFF
--- a/eng/GitHubAppToken.psm1
+++ b/eng/GitHubAppToken.psm1
@@ -1,0 +1,104 @@
+function ConvertTo-Base64Url {
+  param([Parameter(Mandatory=$true)] [byte[]] $Bytes)
+
+  [Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function New-GitHubAppJwt {
+  param(
+    [Parameter(Mandatory=$true)] [string] $AppId,
+    [Parameter(Mandatory=$true)] [string] $PrivateKeyPem,
+    [DateTimeOffset] $Now = [DateTimeOffset]::UtcNow
+  )
+
+  $header = [ordered]@{
+    alg = 'RS256'
+    typ = 'JWT'
+  }
+  $payload = [ordered]@{
+    iat = $Now.AddMinutes(-1).ToUnixTimeSeconds()
+    exp = $Now.AddMinutes(5).ToUnixTimeSeconds()
+    iss = $AppId
+  }
+
+  $headerEncoded = ConvertTo-Base64Url ([Text.Encoding]::UTF8.GetBytes(($header | ConvertTo-Json -Compress)))
+  $payloadEncoded = ConvertTo-Base64Url ([Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+  $signingInput = "$headerEncoded.$payloadEncoded"
+
+  $rsa = [Security.Cryptography.RSA]::Create()
+  try {
+    $rsa.ImportFromPem($PrivateKeyPem)
+    $signature = $rsa.SignData(
+      [Text.Encoding]::UTF8.GetBytes($signingInput),
+      [Security.Cryptography.HashAlgorithmName]::SHA256,
+      [Security.Cryptography.RSASignaturePadding]::Pkcs1)
+  }
+  finally {
+    $rsa.Dispose()
+  }
+
+  "$signingInput.$(ConvertTo-Base64Url $signature)"
+}
+
+function Get-GitHubAppInstallationToken {
+  param(
+    [Parameter(Mandatory=$true)] [string] $Jwt,
+    [Parameter(Mandatory=$true)] [string] $InstallationOwner,
+    [string] $GitHubApiUrl = 'https://api.github.com',
+    [scriptblock] $RequestInvoker
+  )
+
+  if (-not $RequestInvoker) {
+    $RequestInvoker = {
+      param($Method, $Uri, $Headers, $Body)
+
+      $parameters = @{
+        Method = $Method
+        Uri = $Uri
+        Headers = $Headers
+      }
+      if ($Body) {
+        $parameters.Body = $Body
+        $parameters.ContentType = 'application/json'
+      }
+      Invoke-RestMethod @parameters
+    }
+  }
+
+  $headers = @{
+    Authorization = "Bearer $Jwt"
+    Accept = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+    'User-Agent' = 'dotnet-workload-versions'
+  }
+
+  $installations = [Collections.Generic.List[object]]::new()
+  $page = 1
+  do {
+    $pageResponse = @(& $RequestInvoker 'GET' "$GitHubApiUrl/app/installations?per_page=100&page=$page" $headers $null)
+    foreach ($installation in $pageResponse) {
+      $installations.Add($installation)
+    }
+    $page++
+  } while ($pageResponse.Count -eq 100)
+
+  $matches = @($installations | Where-Object { $_.account.login -ieq $InstallationOwner })
+  if ($matches.Count -eq 0) {
+    $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
+    throw "No GitHub App installation found for '$InstallationOwner'. Installations found: $found"
+  }
+  if ($matches.Count -ne 1) {
+    $ids = ($matches | ForEach-Object { $_.id }) -join ', '
+    throw "Multiple GitHub App installations found for '$InstallationOwner': $ids"
+  }
+
+  $requestBody = @{
+    permissions = @{
+      contents = 'read'
+    }
+  } | ConvertTo-Json -Depth 3 -Compress
+
+  & $RequestInvoker 'POST' "$GitHubApiUrl/app/installations/$($matches[0].id)/access_tokens" $headers $requestBody
+}
+
+Export-ModuleMember -Function New-GitHubAppJwt, Get-GitHubAppInstallationToken

--- a/eng/download-workloads.ps1
+++ b/eng/download-workloads.ps1
@@ -4,7 +4,7 @@
 
 # $workloadPath: The path to the directory as output for the workload ZIPs. This is --output-dir in the DARC command for the workload drop .zip downloads.
 # - Example Value: "$(RepoRoot)artifacts\workloads"
-# $gitHubPat: The GitHub PAT to use for DARC (CI build only). See workload-build.yml for converting the PAT to SecureString.
+# $gitHubPat: The GitHub credential to use for DARC (CI build only). This can be a PAT or a GitHub App installation token.
 # $azDOPat: The Azure DevOps PAT to use for DARC (CI build only). See workload-build.yml for converting the PAT to SecureString.
 # $workloadListJson: The JSON string of the list of workload drop names to download. If not provided, all workloads found in Version.Details.xml will be downloaded.
 # - See the workloadDropNames parameter in official.yml for the list generally passed to this script.

--- a/eng/get-github-app-token.ps1
+++ b/eng/get-github-app-token.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)] [string] $KeyVaultName,
+  [Parameter(Mandatory=$true)] [string] $AppSecretName,
+  [Parameter(Mandatory=$true)] [string] $InstallationOwner,
+  [Parameter(Mandatory=$true)] [string] $OutputVariableName
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+Import-Module "$PSScriptRoot/GitHubAppToken.psm1" -Force
+
+function Get-KeyVaultSecretValue {
+  param([Parameter(Mandatory=$true)] [string] $Name)
+
+  $secretJson = az keyvault secret show `
+    --vault-name $KeyVaultName `
+    --name $Name `
+    --output json `
+    --only-show-errors
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to read secret '$Name' from Key Vault '$KeyVaultName'."
+  }
+
+  ($secretJson | ConvertFrom-Json).value
+}
+
+$appId = Get-KeyVaultSecretValue "$AppSecretName-app-id"
+$privateKey = Get-KeyVaultSecretValue "$AppSecretName-app-private-key"
+
+try {
+  $jwt = New-GitHubAppJwt -AppId $appId -PrivateKeyPem $privateKey
+  $tokenResponse = Get-GitHubAppInstallationToken `
+    -Jwt $jwt `
+    -InstallationOwner $InstallationOwner
+}
+finally {
+  $privateKey = $null
+}
+
+if ([string]::IsNullOrWhiteSpace($tokenResponse.token)) {
+  throw "GitHub did not return an installation token for '$InstallationOwner'."
+}
+
+Write-Host "Got an installation token for '$InstallationOwner' that expires at $($tokenResponse.expires_at)."
+Write-Host "##vso[task.setvariable variable=$OutputVariableName;issecret=true]$($tokenResponse.token)"

--- a/eng/get-github-app-token.ps1
+++ b/eng/get-github-app-token.ps1
@@ -14,16 +14,41 @@ Import-Module "$PSScriptRoot/GitHubAppToken.psm1" -Force
 function Get-KeyVaultSecretValue {
   param([Parameter(Mandatory=$true)] [string] $Name)
 
-  $secretJson = az keyvault secret show `
-    --vault-name $KeyVaultName `
-    --name $Name `
-    --output json `
-    --only-show-errors
-  if ($LASTEXITCODE -ne 0) {
-    throw "Failed to read secret '$Name' from Key Vault '$KeyVaultName'."
+  $escapedSecretName = [Uri]::EscapeDataString($Name)
+  $secretUri = "https://$KeyVaultName.vault.azure.net/secrets/$escapedSecretName`?api-version=7.4"
+  try {
+    $response = Invoke-RestMethod `
+      -Uri $secretUri `
+      -Headers @{ Authorization = "Bearer $keyVaultAccessToken" } `
+      -Method Get
+  }
+  catch {
+    throw "Failed to read secret '$Name' from Key Vault '$KeyVaultName': $_"
   }
 
-  ($secretJson | ConvertFrom-Json).value
+  if ([string]::IsNullOrWhiteSpace($response.value)) {
+    throw "Secret '$Name' in Key Vault '$KeyVaultName' is empty."
+  }
+
+  $response.value
+}
+
+$previousNativeCommandErrorPreference = $PSNativeCommandUseErrorActionPreference
+try {
+  # Azure CLI can emit non-fatal Python warnings to stderr.
+  $PSNativeCommandUseErrorActionPreference = $false
+  $keyVaultAccessToken = az account get-access-token `
+    --resource https://vault.azure.net `
+    --query accessToken `
+    --output tsv `
+    --only-show-errors
+  $tokenExitCode = $LASTEXITCODE
+}
+finally {
+  $PSNativeCommandUseErrorActionPreference = $previousNativeCommandErrorPreference
+}
+if ($tokenExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($keyVaultAccessToken)) {
+  throw "Failed to acquire an Azure Key Vault access token."
 }
 
 $appId = Get-KeyVaultSecretValue "$AppSecretName-app-id"

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -151,7 +151,6 @@ variables:
 ############### GROUPS ###############
 # Provides TSA variables for automatic bug reporting.
 - group: DotNet-CLI-SDLValidation-Params
-- group: DotNetBot-GitHub-AllBranches
 
 resources:
   repositories:

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -87,6 +87,20 @@ jobs:
             $workloadNupkgExcludeListJson = $workloadNupkgExcludeList -replace '\r?\n\s*', ''
             Write-Host "##vso[task.setvariable variable=WorkloadNupkgExcludeListJson]$workloadNupkgExcludeListJson"
           displayName: 🟣 Set WorkloadNupkgExcludeListJson variable
+        - pwsh: eng/tests/GitHubAppToken.Tests.ps1
+          displayName: 🟣 Validate GitHub App token flow
+        - task: AzureCLI@2
+          displayName: 🟣 Get GitHub App installation token
+          inputs:
+            azureSubscription: dnceng-workload-versions-githubapp
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              & '$(System.DefaultWorkingDirectory)/eng/get-github-app-token.ps1' `
+                -KeyVaultName EngKeyVault `
+                -AppSecretName workload-versions-github-app `
+                -InstallationOwner dotnet `
+                -OutputVariableName GitHubAppInstallationToken
         - task: AzureCLI@2
           displayName: 🟣 Download workloads
           inputs:
@@ -97,7 +111,7 @@ jobs:
               $azDOToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
               & '$(System.DefaultWorkingDirectory)/eng/download-workloads.ps1' `
                 -workloadPath '$(System.DefaultWorkingDirectory)/artifacts/workloads' `
-                -gitHubPat (ConvertTo-SecureString -String '$(BotAccount-dotnet-bot-repo-PAT)' -AsPlainText -Force) `
+                -gitHubPat (ConvertTo-SecureString -String '$(GitHubAppInstallationToken)' -AsPlainText -Force) `
                 -azDOPat (ConvertTo-SecureString -String $azDOToken -AsPlainText -Force) `
                 -workloadListJson '$(WorkloadListJson)' `
                 -usePreComponents:$${{ parameters.usePreComponentsForVSInsertion }} `

--- a/eng/pipelines/templates/jobs/workload-build.yml
+++ b/eng/pipelines/templates/jobs/workload-build.yml
@@ -87,6 +87,8 @@ jobs:
             $workloadNupkgExcludeListJson = $workloadNupkgExcludeList -replace '\r?\n\s*', ''
             Write-Host "##vso[task.setvariable variable=WorkloadNupkgExcludeListJson]$workloadNupkgExcludeListJson"
           displayName: 🟣 Set WorkloadNupkgExcludeListJson variable
+        # Keep this fast, offline test next to the credential flow so every path that
+        # downloads workloads validates the checked-in compatibility implementation.
         - pwsh: eng/tests/GitHubAppToken.Tests.ps1
           displayName: 🟣 Validate GitHub App token flow
         - task: AzureCLI@2

--- a/eng/tests/GitHubAppToken.Tests.ps1
+++ b/eng/tests/GitHubAppToken.Tests.ps1
@@ -1,0 +1,89 @@
+$ErrorActionPreference = 'Stop'
+
+Import-Module "$PSScriptRoot/../GitHubAppToken.psm1" -Force
+
+function Assert-Equal {
+  param($Expected, $Actual, [string] $Message)
+  if ($Expected -ne $Actual) {
+    throw "$Message Expected '$Expected', got '$Actual'."
+  }
+}
+
+function ConvertFrom-Base64Url {
+  param([Parameter(Mandatory=$true)] [string] $Value)
+
+  $base64 = $Value.Replace('-', '+').Replace('_', '/')
+  switch ($base64.Length % 4) {
+    2 { $base64 += '==' }
+    3 { $base64 += '=' }
+  }
+  [Convert]::FromBase64String($base64)
+}
+
+$rsa = [Security.Cryptography.RSA]::Create(2048)
+try {
+  $privateKey = $rsa.ExportRSAPrivateKeyPem()
+  $now = [DateTimeOffset]::Parse('2026-09-08T20:00:00Z')
+  $jwt = New-GitHubAppJwt -AppId '4876385' -PrivateKeyPem $privateKey -Now $now
+  $segments = $jwt.Split('.')
+
+  Assert-Equal 3 $segments.Count 'JWT must have three segments.'
+  $header = [Text.Encoding]::UTF8.GetString((ConvertFrom-Base64Url $segments[0])) | ConvertFrom-Json
+  $payload = [Text.Encoding]::UTF8.GetString((ConvertFrom-Base64Url $segments[1])) | ConvertFrom-Json
+  Assert-Equal 'RS256' $header.alg 'JWT algorithm is incorrect.'
+  Assert-Equal '4876385' $payload.iss 'JWT issuer is incorrect.'
+  Assert-Equal $now.AddMinutes(-1).ToUnixTimeSeconds() $payload.iat 'JWT issued-at time is incorrect.'
+  Assert-Equal $now.AddMinutes(5).ToUnixTimeSeconds() $payload.exp 'JWT expiration is incorrect.'
+
+  $signatureValid = $rsa.VerifyData(
+    [Text.Encoding]::UTF8.GetBytes("$($segments[0]).$($segments[1])"),
+    (ConvertFrom-Base64Url $segments[2]),
+    [Security.Cryptography.HashAlgorithmName]::SHA256,
+    [Security.Cryptography.RSASignaturePadding]::Pkcs1)
+  Assert-Equal $true $signatureValid 'JWT signature is invalid.'
+}
+finally {
+  $privateKey = $null
+  $rsa.Dispose()
+}
+
+$requests = [Collections.Generic.List[object]]::new()
+$requestInvoker = {
+  param($Method, $Uri, $Headers, $Body)
+
+  $requests.Add([pscustomobject]@{
+    Method = $Method
+    Uri = $Uri
+    Body = $Body
+  })
+  if ($Method -eq 'GET') {
+    return @([pscustomobject]@{
+      id = 42
+      account = [pscustomobject]@{ login = 'dotnet' }
+    })
+  }
+  [pscustomobject]@{
+    token = 'test-installation-token'
+    expires_at = '2026-09-08T21:00:00Z'
+  }
+}.GetNewClosure()
+
+$response = Get-GitHubAppInstallationToken `
+  -Jwt 'test-jwt' `
+  -InstallationOwner 'dotnet' `
+  -GitHubApiUrl 'https://example.invalid' `
+  -RequestInvoker $requestInvoker
+
+Assert-Equal 'test-installation-token' $response.token 'Installation token was not returned.'
+Assert-Equal 2 $requests.Count 'Unexpected number of GitHub API requests.'
+Assert-Equal 'GET' $requests[0].Method 'The first request must list installations.'
+Assert-Equal 'POST' $requests[1].Method 'The second request must mint a token.'
+Assert-Equal 'read' (($requests[1].Body | ConvertFrom-Json).permissions.contents) 'Token permissions were not downscoped.'
+
+$officialPipeline = Get-Content "$PSScriptRoot/../pipelines/official.yml" -Raw
+$workloadJob = Get-Content "$PSScriptRoot/../pipelines/templates/jobs/workload-build.yml" -Raw
+if ($officialPipeline -match 'DotNetBot-GitHub-AllBranches' -or $workloadJob -match 'BotAccount-dotnet-bot-repo-PAT') {
+  throw 'The workload pipeline must not retain a fallback to BotAccount-dotnet-bot-repo-PAT.'
+}
+
+Write-Host 'GitHub App token tests passed.'


### PR DESCRIPTION
## Summary

- mint a short-lived GitHub App installation token from the App ID and private key stored by Secret Manager in EngKeyVault
- explicitly downscope the token to `Contents: read`
- pass the token to Darc through its existing `--github-pat` compatibility argument
- remove the `DotNetBot-GitHub-AllBranches` variable group and all fallback use of `BotAccount-dotnet-bot-repo-PAT`
- add executable tests for JWT signing, installation lookup, permission downscoping, and absence of the PAT fallback

## Infrastructure prerequisites

This PR remains a draft until:

- [x] [dotnet/arcade#17512](https://github.com/dotnet/arcade/pull/17512) is merged and Secret Manager populates `workload-versions-github-app-app-id` and `workload-versions-github-app-app-private-key`
- [x] the `dotnet Workload Versions Reader` App is installed on `dotnet/android`, `dotnet/macios`, and `dotnet/maui`
- [x] the dedicated `dnceng-workload-versions-githubapp` WIF service connection is created
- [x] the service connection has secret-level `Key Vault Secrets User` access only to the App ID and private-key secrets
- [x] pipeline 1298 is authorized to use the service connection
- [x] the compatibility implementation uses Arcade's hosted-agent-safe Key Vault REST pattern
- [x] [pipeline 1298 build 3073589](https://dev.azure.com/dnceng/internal/_build/results?buildId=3073589) succeeded end-to-end with the GitHub App token and no PAT fallback

The `eng` branch currently retains a compatibility implementation because pipeline 1298 overlays it onto source branches with different Arcade GitHub App helper contracts. It can move to the shared helper after those branches converge on the secret-based contract.

Current `main` dependency metadata requires GitHub access to `dotnet/android`, `dotnet/macios`, and `dotnet/maui`. The `emsdk` and `mono` dependencies currently resolve through the internal `dotnet-dotnet` Azure DevOps mirror. Older release branches reference additional GitHub repositories and require a separate scope decision before using this pipeline against them.

Marc Paine offered to review and test once the implementation is available and has been tagged in this PR.

AB#12317
## Validation

Official pipeline [1298 build 3073589](https://dev.azure.com/dnceng/internal/_build/results?buildId=3073589) succeeded against the PR merge result (`cc1fb9d`) with `sourceBranch=main` and `downloadWorkloadNupkgs=true`. Package publishing, NuGet publishing, and VS insertion were disabled for the validation run.

The run confirmed:

- the checked-in GitHub App token tests passed
- the pipeline minted a short-lived installation token for `dotnet`
- workload downloads completed successfully through the GitHub App token path
- the SDL source-analysis and Build stages succeeded